### PR TITLE
Update examples, fix some Bikeshed warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -191,7 +191,7 @@ To <dfn>Construct a Magnetometer Object</dfn>, or to <dfn>Construct an Uncalibra
 ### Magnetometer.x ### {#magnetometer-x}
 
 
-The {{Magnetometer/x!!attribute}} attribute of the {{Magnetometer}}
+The {{Magnetometer/x}} attribute of the {{Magnetometer}}
 interface represents the <a>magnetic field</a> around X-axis.
 In other words, this attribute returns [=latest reading=]["x"].
 
@@ -199,7 +199,7 @@ In other words, this attribute returns [=latest reading=]["x"].
 ### Magnetometer.y ### {#magnetometer-y}
 
 
-The {{Magnetometer/y!!attribute}} attribute of the {{Magnetometer}}
+The {{Magnetometer/y}} attribute of the {{Magnetometer}}
 interface represents the <a>magnetic field</a> around Y-axis.
 In other words, this attribute returns [=latest reading=]["y"].
 
@@ -207,7 +207,7 @@ In other words, this attribute returns [=latest reading=]["y"].
 ### Magnetometer.z ### {#magnetometer-z}
 
 
-The {{Magnetometer/z!!attribute}} attribute of the {{Magnetometer}}
+The {{Magnetometer/z}} attribute of the {{Magnetometer}}
 interface represents the <a>magnetic field</a> around Z-axis.
 In other words, this attribute returns [=latest reading=]["z"].
 
@@ -215,7 +215,7 @@ In other words, this attribute returns [=latest reading=]["z"].
 ### UncalibratedMagnetometer.x ### {#uncalibrated-magnetometer-x}
 
 
-The {{UncalibratedMagnetometer/x!!attribute}} attribute of the {{UncalibratedMagnetometer}}
+The {{UncalibratedMagnetometer/x}} attribute of the {{UncalibratedMagnetometer}}
 interface represents the <a>uncalibrated magnetic field</a> around X-axis.
 In other words, this attribute returns [=latest reading=]["x"].
 
@@ -223,7 +223,7 @@ In other words, this attribute returns [=latest reading=]["x"].
 ### UncalibratedMagnetometer.y ### {#uncalibrated-magnetometer-y}
 
 
-The {{UncalibratedMagnetometer/y!!attribute}} attribute of the {{UncalibratedMagnetometer}}
+The {{UncalibratedMagnetometer/y}} attribute of the {{UncalibratedMagnetometer}}
 interface represents the <a>uncalibrated magnetic field</a> around Y-axis.
 In other words, this attribute returns [=latest reading=]["y"].
 
@@ -231,7 +231,7 @@ In other words, this attribute returns [=latest reading=]["y"].
 ### UncalibratedMagnetometer.z ### {#uncalibrated-magnetometer-z}
 
 
-The {{UncalibratedMagnetometer/z!!attribute}} attribute of the {{UncalibratedMagnetometer}}
+The {{UncalibratedMagnetometer/z}} attribute of the {{UncalibratedMagnetometer}}
 interface represents the <a>uncalibrated magnetic field</a> around Z-axis.
 In other words, this attribute returns [=latest reading=]["z"].
 
@@ -239,21 +239,21 @@ In other words, this attribute returns [=latest reading=]["z"].
 ### UncalibratedMagnetometer.xBias ### {#uncalibrated-magnetometer-xBias}
 
 
-The {{UncalibratedMagnetometer/xBias!!attribute}} attribute of the {{UncalibratedMagnetometer}}
+The {{UncalibratedMagnetometer/xBias}} attribute of the {{UncalibratedMagnetometer}}
 interface represents the <a>hard iron distortion</a> correction around X-axis.
 In other words, this attribute returns [=latest reading=]["xBias"].
 
 ### UncalibratedMagnetometer.yBias ### {#uncalibrated-magnetometer-yBias}
 
 
-The {{UncalibratedMagnetometer/yBias!!attribute}} attribute of the {{UncalibratedMagnetometer}}
+The {{UncalibratedMagnetometer/yBias}} attribute of the {{UncalibratedMagnetometer}}
 interface represents the <a>hard iron distortion</a> correction around Y-axis.
 In other words, this attribute returns [=latest reading=]["yBias"].
 
 ### UncalibratedMagnetometer.zBias ### {#uncalibrated-magnetometer-zBias}
 
 
-The {{UncalibratedMagnetometer/zBias!!attribute}} attribute of the {{UncalibratedMagnetometer}}
+The {{UncalibratedMagnetometer/zBias}} attribute of the {{UncalibratedMagnetometer}}
 interface represents the <a>hard iron distortion</a> correction around Z-axis.
 In other words, this attribute returns [=latest reading=]["zBias"].
 
@@ -268,7 +268,7 @@ The direction and magnitude of the Earth’s field changes with location, latitu
 the magnitude is lowest near the equator and highest near the poles.
 Some hard-iron interference, meaning presence of permanent magnets (e.g. magnets in the speaker of a phone) in the vicinity of the sensor
 also affects the accuracy of the reading.
-Presence of electronic items, laptops, batteries, etc also contribute to the <a>soft iron interference</a>.
+Presence of electronic items, laptops, batteries, etc also contribute to the soft iron interference.
 Flight Mode option in mobile phones might help in decreasing the electro magnetic interference.
 
 In addition to the above spatial variations of the <a>magnetic field</a>, time based variations,
@@ -287,7 +287,7 @@ Magnetometers can be used for a variety of use-cases, such as:
   The user makes coarse gestures in the 3D space around the device using the magnet. Movement of the magnet affects the magnetic field sensed by the compass sensor integrated in the device.
   The temporal pattern of the gesture is then used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
   are some of the use cases.
-- In cases, where it is not possible to use [=orientation-sensor=], user may need to fuse magnetometer data with with other low-level sensor data, to calculate orientation.
+- In cases, where it is not possible to use orientation sensor, user may need to fuse magnetometer data with with other low-level sensor data, to calculate orientation.
 - Indoor navigation system may use magnetometer on mobile phones [[MAGINDOORPOS]]. Specific use cases for indoor navigation may include proximity advertising, way finding in malls or airports, geofencing, etc.
 - Calculating compass heading, more on that in [[#compass]].
 
@@ -313,36 +313,32 @@ To determine geographic north (or true north) heading, add the appropriate <a>de
 By convention, declination is positive when magnetic north is east of true north, and negative when it is to the west. You can get real time value for <a>magnetic declination</a> e.g. using the <a href="http://www.ngdc.noaa.gov/geomag-web/calculators/declinationHelp">Magnetic declination calculator</a>
 provided by the National Oceanic and Atmospheric Administration (NOAA).
 
-Magnetic north calculation is simple:
+The magnetic north is calculated as follows:
 
 <div class="example">
   <pre highlight="js">
     let sensor = new Magnetometer();
     sensor.start();
-    var headingDegrees = Math.atan2(sensor.y,
-                                    sensor.x) * (180 / Math.PI);
-
-    console.log('Heading in degrees: ' + headingDegrees);
+    let heading = Math.atan2(sensor.y, sensor.x) * (180 / Math.PI);
+    console.log('Heading in degrees: ' + heading);
   </pre>
 </div>
 
-To get geographic north (or true north) that considers the
-<a>magnetic declination</a> at the given latitude and longitude,
-further work is required:
+The geographic north at a given latitude and longitude is calculated as follows:
 
 <div class="example">
   <pre highlight="js">
-    // First, get the latitude and longitude (omitted for brevity).
-    var latitude = 0, longitude = 0;
+    // Get the latitude and longitude, omitted for brevity here.
+    let latitude = 0, longitude = 0;
 
-    // Then, get the magnetic declination using your favorite web service.
-    var base = 'https://www.ngdc.noaa.gov/geomag-web/calculators/calculateDeclination';
-    fetch(base + '?lat1=' + latitude + '&lon1=' + longitude + '&resultFormat=csv')
+    // Get the magnetic declination at the given latitude and longitude.
+    fetch('https://www.ngdc.noaa.gov/geomag-web/calculators/calculateDeclination' +
+          '?lat1=' + latitude + '&lon1=' + longitude + '&resultFormat=csv')
       .then(response => response.text()).then(text => {
-        var declinationDegrees =
-            parseFloat(text.replace(/^#.*$/gm, '').trim().split(',')[4]);
-        // Compensate for the magnetic declination to get the true north.
-        console.log('True heading in degrees: ' + (headingDegrees + declinationDegrees));
+        let declination = parseFloat(text.replace(/^#.*$/gm, '').trim().split(',')[4]);
+
+        // Compensate for the magnetic declination to get the geographic north.
+        console.log('True heading in degrees: ' + (heading + declination));
     });
     </pre>
 </div>

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 3e4ecbe0ef0589381cdca6fa15e8ab0ea3856450" name="generator">
+  <meta content="Bikeshed version bab6032cf8759f7d2fb1341d02aa48484a5a3187" name="generator">
   <link href="https://www.w3.org/TR/magnetometer/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1371,67 +1371,67 @@ Possible extra rowspan handling
         </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-        code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        </style>
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Magnetometer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-10">10 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-26">26 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1556,16 +1556,16 @@ and as such reports changes in the <a data-link-type="dfn" href="#magnetic-field
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <div class="example" id="example-7bdf3704">
     <a class="self-link" href="#example-7bdf3704"></a> 
-<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Magnetometer<span class="p">(</span><span class="p">)</span><span class="p">;</span>
-sensor<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Magnetometer<span class="p">();</span>
+sensor<span class="p">.</span>start<span class="p">();</span>
 
-sensor<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
-    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Magnetic field along the X-axis "</span> <span class="o">+</span> sensor<span class="p">.</span>x<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Magnetic field along the Y-axis "</span> <span class="o">+</span> sensor<span class="p">.</span>y<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Magnetic field along the Z-axis "</span> <span class="o">+</span> sensor<span class="p">.</span>z<span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">;</span>
+sensor<span class="p">.</span>onchange <span class="o">=</span> <span class="p">()</span> <span class="o">=></span> <span class="p">{</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Magnetic field along the X-axis "</span> <span class="o">+</span> sensor<span class="p">.</span>x<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Magnetic field along the Y-axis "</span> <span class="o">+</span> sensor<span class="p">.</span>y<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Magnetic field along the Z-axis "</span> <span class="o">+</span> sensor<span class="p">.</span>z<span class="p">);</span>
+<span class="p">};</span>
 
-sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">)</span><span class="p">;</span>
+sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">);</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="3" id="security-and-privacy"><span class="secno">3. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
@@ -1584,51 +1584,51 @@ the device’s screen when the device in its default orientation (see figure bel
    <p><img alt="Magnetometer coordinate system." src="images/magnetometer_coordinate_system.png" srcset="images/magnetometer_coordinate_system.svg"></p>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="magnetometer-interface"><span class="secno">5.1. </span><span class="content">The Magnetometer Interface</span><a class="self-link" href="#magnetometer-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Magnetometer" data-dfn-type="constructor" data-export="" data-lt="Magnetometer(sensorOptions)|Magnetometer()" id="dom-magnetometer-magnetometer">Constructor<a class="self-link" href="#dom-magnetometer-magnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Magnetometer/Magnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-magnetometer-magnetometer-sensoroptions-sensoroptions">sensorOptions<a class="self-link" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="magnetometer">Magnetometer</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-magnetometer-x">x</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-magnetometer-y">y</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-magnetometer-z">z</dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Magnetometer" data-dfn-type="constructor" data-export="" data-lt="Magnetometer(sensorOptions)|Magnetometer()" id="dom-magnetometer-magnetometer"><code>Constructor</code><a class="self-link" href="#dom-magnetometer-magnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Magnetometer/Magnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="magnetometer"><code>Magnetometer</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-magnetometer-x"><code>x</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-magnetometer-y"><code>y</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-magnetometer-z"><code>z</code></dfn>;
 };
 </pre>
    <h3 class="heading settled" data-level="5.2" id="uncalibrated-magnetometer-interface"><span class="secno">5.2. </span><span class="content">The UncalibratedMagnetometer Interface</span><a class="self-link" href="#uncalibrated-magnetometer-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="constructor" data-export="" data-lt="UncalibratedMagnetometer(sensorOptions)|UncalibratedMagnetometer()" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer">Constructor<a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer/UncalibratedMagnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions">sensorOptions<a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="uncalibratedmagnetometer">UncalibratedMagnetometer</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-x">x</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-y">y</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-z">z</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-xbias">xBias</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-ybias">yBias</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-zbias">zBias</dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="constructor" data-export="" data-lt="UncalibratedMagnetometer(sensorOptions)|UncalibratedMagnetometer()" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><code>Constructor</code><a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer/UncalibratedMagnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="uncalibratedmagnetometer"><code>UncalibratedMagnetometer</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-x"><code>x</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-y"><code>y</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-z"><code>z</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-xbias"><code>xBias</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-ybias"><code>yBias</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-uncalibratedmagnetometer-zbias"><code>zBias</code></dfn>;
 };
 </pre>
    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-magnetometer-object">Construct a Magnetometer Object<a class="self-link" href="#construct-a-magnetometer-object"></a></dfn>, or to <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-uncalibratedmagnetometer-object">Construct an UncalibratedMagnetometer Object<a class="self-link" href="#construct-an-uncalibratedmagnetometer-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
    <h4 class="heading settled" data-level="5.2.1" id="magnetometer-x"><span class="secno">5.2.1. </span><span class="content">Magnetometer.x</span><a class="self-link" href="#magnetometer-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer-4">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-10">magnetic field</a> around X-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer-4">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-10">magnetic field</a> around X-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"].</p>
    <h4 class="heading settled" data-level="5.2.2" id="magnetometer-y"><span class="secno">5.2.2. </span><span class="content">Magnetometer.y</span><a class="self-link" href="#magnetometer-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-y" id="ref-for-dom-magnetometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer-5">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-11">magnetic field</a> around Y-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-magnetometer-y" id="ref-for-dom-magnetometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer-5">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-11">magnetic field</a> around Y-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"].</p>
    <h4 class="heading settled" data-level="5.2.3" id="magnetometer-z"><span class="secno">5.2.3. </span><span class="content">Magnetometer.z</span><a class="self-link" href="#magnetometer-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-z" id="ref-for-dom-magnetometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer-6">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-12">magnetic field</a> around Z-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-magnetometer-z" id="ref-for-dom-magnetometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer-6">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-12">magnetic field</a> around Z-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"].</p>
    <h4 class="heading settled" data-level="5.2.4" id="uncalibrated-magnetometer-x"><span class="secno">5.2.4. </span><span class="content">UncalibratedMagnetometer.x</span><a class="self-link" href="#uncalibrated-magnetometer-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-x" id="ref-for-dom-uncalibratedmagnetometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-4">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field-4">uncalibrated magnetic field</a> around X-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-uncalibratedmagnetometer-x" id="ref-for-dom-uncalibratedmagnetometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-4">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field-4">uncalibrated magnetic field</a> around X-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"].</p>
    <h4 class="heading settled" data-level="5.2.5" id="uncalibrated-magnetometer-y"><span class="secno">5.2.5. </span><span class="content">UncalibratedMagnetometer.y</span><a class="self-link" href="#uncalibrated-magnetometer-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-y" id="ref-for-dom-uncalibratedmagnetometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-5">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field-5">uncalibrated magnetic field</a> around Y-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-uncalibratedmagnetometer-y" id="ref-for-dom-uncalibratedmagnetometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-5">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field-5">uncalibrated magnetic field</a> around Y-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"].</p>
    <h4 class="heading settled" data-level="5.2.6" id="uncalibrated-magnetometer-z"><span class="secno">5.2.6. </span><span class="content">UncalibratedMagnetometer.z</span><a class="self-link" href="#uncalibrated-magnetometer-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-z" id="ref-for-dom-uncalibratedmagnetometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-6">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field-6">uncalibrated magnetic field</a> around Z-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-uncalibratedmagnetometer-z" id="ref-for-dom-uncalibratedmagnetometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-6">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field-6">uncalibrated magnetic field</a> around Z-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"].</p>
    <h4 class="heading settled" data-level="5.2.7" id="uncalibrated-magnetometer-xBias"><span class="secno">5.2.7. </span><span class="content">UncalibratedMagnetometer.xBias</span><a class="self-link" href="#uncalibrated-magnetometer-xBias"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-xbias" id="ref-for-dom-uncalibratedmagnetometer-xbias-1">xBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-7">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion-5">hard iron distortion</a> correction around X-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-uncalibratedmagnetometer-xbias" id="ref-for-dom-uncalibratedmagnetometer-xbias-1">xBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-7">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion-5">hard iron distortion</a> correction around X-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["xBias"].</p>
    <h4 class="heading settled" data-level="5.2.8" id="uncalibrated-magnetometer-yBias"><span class="secno">5.2.8. </span><span class="content">UncalibratedMagnetometer.yBias</span><a class="self-link" href="#uncalibrated-magnetometer-yBias"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-ybias" id="ref-for-dom-uncalibratedmagnetometer-ybias-1">yBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-8">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion-6">hard iron distortion</a> correction around Y-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-uncalibratedmagnetometer-ybias" id="ref-for-dom-uncalibratedmagnetometer-ybias-1">yBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-8">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion-6">hard iron distortion</a> correction around Y-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["yBias"].</p>
    <h4 class="heading settled" data-level="5.2.9" id="uncalibrated-magnetometer-zBias"><span class="secno">5.2.9. </span><span class="content">UncalibratedMagnetometer.zBias</span><a class="self-link" href="#uncalibrated-magnetometer-zBias"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-zbias" id="ref-for-dom-uncalibratedmagnetometer-zbias-1">zBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-9">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion-7">hard iron distortion</a> correction around Z-axis.
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-uncalibratedmagnetometer-zbias" id="ref-for-dom-uncalibratedmagnetometer-zbias-1">zBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer-9">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion-7">hard iron distortion</a> correction around Z-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["zBias"].</p>
    <h2 class="heading settled" data-level="6" id="limitations-magnetometer"><span class="secno">6. </span><span class="content">Limitations of Magnetometer Sensors</span><a class="self-link" href="#limitations-magnetometer"></a></h2>
    <p><em>This section is non-normative</em>.</p>
@@ -1636,7 +1636,7 @@ In other words, this attribute returns <a data-link-type="dfn" href="https://w3c
 the magnitude is lowest near the equator and highest near the poles.
 Some hard-iron interference, meaning presence of permanent magnets (e.g. magnets in the speaker of a phone) in the vicinity of the sensor
 also affects the accuracy of the reading.
-Presence of electronic items, laptops, batteries, etc also contribute to the <a data-link-type="dfn">soft iron interference</a>.
+Presence of electronic items, laptops, batteries, etc also contribute to the soft iron interference.
 Flight Mode option in mobile phones might help in decreasing the electro magnetic interference.</p>
    <p>In addition to the above spatial variations of the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field-13">magnetic field</a>, time based variations,
 like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the earth.</p>
@@ -1653,7 +1653,7 @@ The user makes coarse gestures in the 3D space around the device using the magne
 The temporal pattern of the gesture is then used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
 are some of the use cases.</p>
     <li data-md="">
-     <p>In cases, where it is not possible to use <a data-link-type="dfn">orientation-sensor</a>, user may need to fuse magnetometer data with with other low-level sensor data, to calculate orientation.</p>
+     <p>In cases, where it is not possible to use orientation sensor, user may need to fuse magnetometer data with with other low-level sensor data, to calculate orientation.</p>
     <li data-md="">
      <p>Indoor navigation system may use magnetometer on mobile phones <a data-link-type="biblio" href="#biblio-magindoorpos">[MAGINDOORPOS]</a>. Specific use cases for indoor navigation may include proximity advertising, way finding in malls or airports, geofencing, etc.</p>
     <li data-md="">
@@ -1673,33 +1673,30 @@ is, the directions planar with the earth’s surface.
 To determine geographic north (or true north) heading, add the appropriate <a data-link-type="dfn" href="#declination-angle" id="ref-for-declination-angle-2">declination angle</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="magnetic-declination">Magnetic declination</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="declination-angle">declination angle</dfn> is the angle on the horizontal plane between magnetic north and the true north and depends on the position on the Earth’s surface, and changes over time.
 By convention, declination is positive when magnetic north is east of true north, and negative when it is to the west. You can get real time value for <a data-link-type="dfn" href="#magnetic-declination" id="ref-for-magnetic-declination-1">magnetic declination</a> e.g. using the <a href="http://www.ngdc.noaa.gov/geomag-web/calculators/declinationHelp">Magnetic declination calculator</a> provided by the National Oceanic and Atmospheric Administration (NOAA).</p>
-   <p>Magnetic north calculation is simple:</p>
-   <div class="example" id="example-45e74fc9">
-    <a class="self-link" href="#example-45e74fc9"></a> 
-<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Magnetometer<span class="p">(</span><span class="p">)</span><span class="p">;</span>
-sensor<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
-<span class="kd">var</span> headingDegrees <span class="o">=</span> Math<span class="p">.</span>atan2<span class="p">(</span>sensor<span class="p">.</span>y<span class="p">,</span>
-                                sensor<span class="p">.</span>x<span class="p">)</span> <span class="o">*</span> <span class="p">(</span><span class="mi">180</span> <span class="o">/</span> Math<span class="p">.</span>PI<span class="p">)</span><span class="p">;</span>
-
-console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Heading in degrees: '</span> <span class="o">+</span> headingDegrees<span class="p">)</span><span class="p">;</span>
+   <p>The magnetic north is calculated as follows:</p>
+   <div class="example" id="example-7be8f1e8">
+    <a class="self-link" href="#example-7be8f1e8"></a> 
+<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Magnetometer<span class="p">();</span>
+sensor<span class="p">.</span>start<span class="p">();</span>
+<span class="kd">let</span> heading <span class="o">=</span> Math<span class="p">.</span>atan2<span class="p">(</span>sensor<span class="p">.</span>y<span class="p">,</span> sensor<span class="p">.</span>x<span class="p">)</span> <span class="o">*</span> <span class="p">(</span><span class="mi">180</span> <span class="o">/</span> Math<span class="p">.</span>PI<span class="p">);</span>
+console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Heading in degrees: '</span> <span class="o">+</span> heading<span class="p">);</span>
 </pre>
    </div>
-   <p>To get geographic north (or true north) that considers the <a data-link-type="dfn" href="#magnetic-declination" id="ref-for-magnetic-declination-2">magnetic declination</a> at the given latitude and longitude,
-further work is required:</p>
-   <div class="example" id="example-721a04cc">
-    <a class="self-link" href="#example-721a04cc"></a> 
-<pre class="highlight"><span class="c1">// First, get the latitude and longitude (omitted for brevity).
-</span><span class="kd">var</span> latitude <span class="o">=</span> <span class="mi">0</span><span class="p">,</span> longitude <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
+   <p>The geographic north at a given latitude and longitude is calculated as follows:</p>
+   <div class="example" id="example-9cb49786">
+    <a class="self-link" href="#example-9cb49786"></a> 
+<pre class="highlight"><span class="c1">// Get the latitude and longitude, omitted for brevity here.
+</span><span class="kd">let</span> latitude <span class="o">=</span> <span class="mi">0</span><span class="p">,</span> longitude <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
 
-<span class="c1">// Then, get the magnetic declination using your favorite web service.
-</span><span class="kd">var</span> base <span class="o">=</span> <span class="s1">'https://www.ngdc.noaa.gov/geomag-web/calculators/calculateDeclination'</span><span class="p">;</span>
-fetch<span class="p">(</span>base <span class="o">+</span> <span class="s1">'?lat1='</span> <span class="o">+</span> latitude <span class="o">+</span> <span class="s1">'&amp;lon1='</span> <span class="o">+</span> longitude <span class="o">+</span> <span class="s1">'&amp;resultFormat=csv'</span><span class="p">)</span>
-  <span class="p">.</span>then<span class="p">(</span>response <span class="p">=></span> response<span class="p">.</span>text<span class="p">(</span><span class="p">)</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span>text <span class="p">=></span> <span class="p">{</span>
-    <span class="kd">var</span> declinationDegrees <span class="o">=</span>
-        parseFloat<span class="p">(</span>text<span class="p">.</span>replace<span class="p">(</span><span class="sr">/^#.*$/gm</span><span class="p">,</span> <span class="s1">''</span><span class="p">)</span><span class="p">.</span>trim<span class="p">(</span><span class="p">)</span><span class="p">.</span>split<span class="p">(</span><span class="s1">','</span><span class="p">)</span><span class="p">[</span><span class="mi">4</span><span class="p">]</span><span class="p">)</span><span class="p">;</span>
-    <span class="c1">// Compensate for the magnetic declination to get the true north.
-</span>    console<span class="p">.</span>log<span class="p">(</span><span class="s1">'True heading in degrees: '</span> <span class="o">+</span> <span class="p">(</span>headingDegrees <span class="o">+</span> declinationDegrees<span class="p">)</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="c1">// Get the magnetic declination at the given latitude and longitude.
+</span>fetch<span class="p">(</span><span class="s1">'https://www.ngdc.noaa.gov/geomag-web/calculators/calculateDeclination'</span> <span class="o">+</span>
+      <span class="s1">'?lat1='</span> <span class="o">+</span> latitude <span class="o">+</span> <span class="s1">'&amp;lon1='</span> <span class="o">+</span> longitude <span class="o">+</span> <span class="s1">'&amp;resultFormat=csv'</span><span class="p">)</span>
+  <span class="p">.</span>then<span class="p">(</span>response <span class="o">=></span> response<span class="p">.</span>text<span class="p">()).</span>then<span class="p">(</span>text <span class="o">=></span> <span class="p">{</span>
+    <span class="kd">let</span> declination <span class="o">=</span> parseFloat<span class="p">(</span>text<span class="p">.</span>replace<span class="p">(</span><span class="sr">/^#.*$/gm</span><span class="p">,</span> <span class="s1">''</span><span class="p">).</span>trim<span class="p">().</span>split<span class="p">(</span><span class="s1">','</span><span class="p">)[</span><span class="mi">4</span><span class="p">]);</span>
+
+    <span class="c1">// Compensate for the magnetic declination to get the geographic north.
+</span>    console<span class="p">.</span>log<span class="p">(</span><span class="s1">'True heading in degrees: '</span> <span class="o">+</span> <span class="p">(</span>heading <span class="o">+</span> declination<span class="p">));</span>
+<span class="p">});</span>
 </pre>
    </div>
    <p class="note" role="note"><span>Note:</span> If the device is not level to the Earth’s surface, a developer needs
@@ -1823,21 +1820,21 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd>Boris Smus. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=445926">Magnetic input for Google cardboard</a>. Informational. URL: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=445926">https://bugs.chromium.org/p/chromium/issues/detail?id=445926</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv" href="#dom-magnetometer-magnetometer"><span class="nv">Constructor</span></a>(<span class="kt"><span class="kt">optional</span></span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions"><span class="n">SensorOptions</span></a> <a class="nv" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><span class="nv">sensorOptions</span></a>)]
-<span class="kt"><span class="kt">interface</span></span> <a class="nv" href="#magnetometer"><span class="nv">Magnetometer</span></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor"><span class="n">Sensor</span></a> {
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-magnetometer-x"><span class="nv">x</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-magnetometer-y"><span class="nv">y</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-magnetometer-z"><span class="nv">z</span></a>;
+<pre class="idl highlight def">[<a class="nv" href="#dom-magnetometer-magnetometer"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <a class="nv" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#magnetometer"><code>Magnetometer</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-magnetometer-x"><code>x</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-magnetometer-y"><code>y</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-magnetometer-z"><code>z</code></a>;
 };
 
-[<a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><span class="nv">Constructor</span></a>(<span class="kt"><span class="kt">optional</span></span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions"><span class="n">SensorOptions</span></a> <a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><span class="nv">sensorOptions</span></a>)]
-<span class="kt"><span class="kt">interface</span></span> <a class="nv" href="#uncalibratedmagnetometer"><span class="nv">UncalibratedMagnetometer</span></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor"><span class="n">Sensor</span></a> {
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-x"><span class="nv">x</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-y"><span class="nv">y</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-z"><span class="nv">z</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-xbias"><span class="nv">xBias</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-ybias"><span class="nv">yBias</span></a>;
-  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt"><span class="kt">unrestricted</span></span> <span class="kt"><span class="kt">double</span></span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-zbias"><span class="nv">zBias</span></a>;
+[<a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#uncalibratedmagnetometer"><code>UncalibratedMagnetometer</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-x"><code>x</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-y"><code>y</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-z"><code>z</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-xbias"><code>xBias</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-ybias"><code>yBias</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-uncalibratedmagnetometer-zbias"><code>zBias</code></a>;
 };
 
 </pre>
@@ -1972,7 +1969,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <aside class="dfn-panel" data-for="magnetic-declination">
    <b><a href="#magnetic-declination">#magnetic-declination</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-magnetic-declination-1">8. Compass Heading Using Magnetometers</a> <a href="#ref-for-magnetic-declination-2">(2)</a>
+    <li><a href="#ref-for-magnetic-declination-1">8. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="declination-angle">


### PR DESCRIPTION
@riju PTAL.

It seems the following remaining Bikeshed link errors are false negatives:

```
LINK ERROR: Multiple possible 'idl' local refs for 'x'.
Arbitrarily chose the one with type 'attribute' and for 'Magnetometer'.
<a data-link-type="idl" data-lt="x">x</a>
LINK ERROR: Multiple possible 'idl' local refs for 'y'.
Arbitrarily chose the one with type 'attribute' and for 'Magnetometer'.
<a data-link-type="idl" data-lt="y">y</a>
 ✔  Successfully generated, with 2 linking errors
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/magnetometer/update-examples.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/magnetometer/030d0f8...eba1292.html)