### PR TITLE
Magnetometer can use the screen local coordinates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,6 +31,12 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: construct a sensor object; url: construct-sensor-object
     text: sensor type
     text: mitigation strategies; url: mitigation-strategies
+    text: local coordinate system
+    text: sensor readings; url: sensor-readings
+urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
+  type: dfn
+    text: device coordinate system
+    text: screen coordinate system
 </pre>
 
 
@@ -161,13 +167,17 @@ For uncalibrated magnetometer, the [=latest reading=] includes three [=map/entri
 and three additional [=map/entries=] whose [=map/keys=] are "xBias", "yBias", "zBias" and whose [=map/values=] contain the <a>hard iron distortion</a> correction around the 3 different axes.
 
 The sign of the <a>magnetic field</a> values must be according to the
-right-hand convention in a <a>local coordinate system</a> defined by the device.
+right-hand convention in a [=local coordinate system=] (see figure below).
 
-Note: The <dfn>local coordinate system</dfn> of a mobile device is usually defined relative to
-the device's screen when the device in its default orientation (see figure below).
 
-<img src="images/magnetometer_coordinate_system.png" srcset="images/magnetometer_coordinate_system.svg" alt="Magnetometer coordinate system.">
+<img src="images/magnetometer_coordinate_system.svg" onerror="this.src='images/magnetometer_coordinate_system.png'" style="display: block;margin: auto;" alt="Magnetometer coordinate system.">
 
+Reference Frame {#reference-frame}
+----------------
+
+The [=local coordinate system=] represents the reference frame for the
+{{Magnetometer}} and the {{UncalibratedMagnetometer}} [=sensor readings|readings=].
+It can be either the [=device coordinate system=] or the [=screen coordinate system=].
 
 API {#api}
 ===
@@ -176,33 +186,24 @@ The Magnetometer Interface {#magnetometer-interface}
 --------------------------------
 
 <pre class="idl">
-  [Constructor(optional SensorOptions sensorOptions), SecureContext, Exposed=Window]
+  [Constructor(optional MagnetometerSensorOptions sensorOptions), SecureContext,
+    Exposed=Window]
   interface Magnetometer : Sensor {
     readonly attribute double? x;
     readonly attribute double? y;
     readonly attribute double? z;
   };
-</pre>
 
+  enum LocalCoordinateSystem { "device", "screen" };
 
-The UncalibratedMagnetometer Interface {#uncalibrated-magnetometer-interface}
---------------------------------
-
-<pre class="idl">
-  [Constructor(optional SensorOptions sensorOptions), SecureContext, Exposed=Window]
-  interface UncalibratedMagnetometer : Sensor {
-    readonly attribute double? x;
-    readonly attribute double? y;
-    readonly attribute double? z;
-    readonly attribute double? xBias;
-    readonly attribute double? yBias;
-    readonly attribute double? zBias;
+  dictionary MagnetometerSensorOptions :  SensorOptions  {
+    LocalCoordinateSystem referenceFrame = "device";
   };
 </pre>
 
-
-To <dfn>Construct a Magnetometer Object</dfn>, or to <dfn>Construct an UncalibratedMagnetometer Object</dfn> the user agent must invoke the <a>construct a Sensor object</a> abstract operation.
-
+To construct a {{Magnetometer}} object the user agent must invoke the
+[=construct a magnetometer object=] abstract operation for the {{Magnetometer}}
+interface.
 
 ### Magnetometer.x ### {#magnetometer-x}
 
@@ -230,6 +231,27 @@ interface represents the <a>magnetic field</a> around Z-axis.
 In other words, this attribute returns the result of invoking
 [=get value from latest reading=] with `this` and "z" as arguments.
 
+
+The UncalibratedMagnetometer Interface {#uncalibrated-magnetometer-interface}
+--------------------------------
+
+<pre class="idl">
+  [Constructor(optional MagnetometerSensorOptions sensorOptions), SecureContext,
+    Exposed=Window]
+  interface UncalibratedMagnetometer : Sensor {
+    readonly attribute double? x;
+    readonly attribute double? y;
+    readonly attribute double? z;
+    readonly attribute double? xBias;
+    readonly attribute double? yBias;
+    readonly attribute double? zBias;
+  };
+</pre>
+
+
+To construct an {{UncalibratedMagnetometer}} object the user agent must invoke the
+[=construct a magnetometer object=] abstract operation for the {{UncalibratedMagnetometer}}
+interface.
 
 ### UncalibratedMagnetometer.x ### {#uncalibrated-magnetometer-x}
 
@@ -283,6 +305,26 @@ In other words, this attribute returns the result of invoking
 [=get value from latest reading=] with `this` and "zBias" as arguments.
 
 
+Abstract Operations {#abstract-opertaions}
+==============
+
+<h3 dfn>Construct a magnetometer object</h3>
+
+<div algorithm="construct a magnetometer object">
+
+    : input
+    :: |options|, a {{MagnetometerSensorOptions}} object.
+    : output
+    :: A {{Sensor}} object.
+
+    1. Let |sensor_instance| be the result of invoking [=construct a Sensor object=] with |options|.
+    1. If |options|.{{referenceFrame!!dict-member}} is "screen", then:
+       1.  Define [=local coordinate system=] for |sensor_instance|
+           as the [=screen coordinate system=].
+    1. Otherwise, define [=local coordinate system=] for |sensor_instance|
+       as the [=device coordinate system=].
+</div>
+
 Limitations of Magnetometer Sensors {#limitations-magnetometer}
 ==============
 
@@ -297,8 +339,6 @@ Flight Mode option in mobile phones might help in decreasing the electro magneti
 
 In addition to the above spatial variations of the <a>magnetic field</a>, time based variations,
 like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the earth.
-
-
 
 Use Cases and Requirements {#usecases-and-requirements}
 ===================

--- a/index.html
+++ b/index.html
@@ -1183,9 +1183,8 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 2d63ad75df4c3282ed7d8d3fb42b0c483a131ce1" name="generator">
+  <meta content="Bikeshed version 166744eb86a34dbc5493268ea410dc65275aa964" name="generator">
   <link href="https://www.w3.org/TR/magnetometer/" rel="canonical">
-  <meta content="fd71365d4dad86dffb37303b1e9cc273459011bd" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1432,7 +1431,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Magnetometer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-18">18 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-08">8 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1457,7 +1456,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -1480,11 +1479,11 @@ field in the X, Y and Z axis.</p>
 	All comments are welcome. </p>
    <p> This document was produced by the <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
+	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1494,30 +1493,42 @@ field in the X, Y and Z axis.</p>
     <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
     <li><a href="#examples"><span class="secno">2</span> <span class="content">Examples</span></a>
     <li><a href="#security-and-privacy"><span class="secno">3</span> <span class="content">Security and Privacy Considerations</span></a>
-    <li><a href="#model"><span class="secno">4</span> <span class="content">Model</span></a>
+    <li>
+     <a href="#model"><span class="secno">4</span> <span class="content">Model</span></a>
+     <ol class="toc">
+      <li><a href="#reference-frame"><span class="secno">4.1</span> <span class="content">Reference Frame</span></a>
+     </ol>
     <li>
      <a href="#api"><span class="secno">5</span> <span class="content">API</span></a>
      <ol class="toc">
-      <li><a href="#magnetometer-interface"><span class="secno">5.1</span> <span class="content">The Magnetometer Interface</span></a>
+      <li>
+       <a href="#magnetometer-interface"><span class="secno">5.1</span> <span class="content">The Magnetometer Interface</span></a>
+       <ol class="toc">
+        <li><a href="#magnetometer-x"><span class="secno">5.1.1</span> <span class="content">Magnetometer.x</span></a>
+        <li><a href="#magnetometer-y"><span class="secno">5.1.2</span> <span class="content">Magnetometer.y</span></a>
+        <li><a href="#magnetometer-z"><span class="secno">5.1.3</span> <span class="content">Magnetometer.z</span></a>
+       </ol>
       <li>
        <a href="#uncalibrated-magnetometer-interface"><span class="secno">5.2</span> <span class="content">The UncalibratedMagnetometer Interface</span></a>
        <ol class="toc">
-        <li><a href="#magnetometer-x"><span class="secno">5.2.1</span> <span class="content">Magnetometer.x</span></a>
-        <li><a href="#magnetometer-y"><span class="secno">5.2.2</span> <span class="content">Magnetometer.y</span></a>
-        <li><a href="#magnetometer-z"><span class="secno">5.2.3</span> <span class="content">Magnetometer.z</span></a>
-        <li><a href="#uncalibrated-magnetometer-x"><span class="secno">5.2.4</span> <span class="content">UncalibratedMagnetometer.x</span></a>
-        <li><a href="#uncalibrated-magnetometer-y"><span class="secno">5.2.5</span> <span class="content">UncalibratedMagnetometer.y</span></a>
-        <li><a href="#uncalibrated-magnetometer-z"><span class="secno">5.2.6</span> <span class="content">UncalibratedMagnetometer.z</span></a>
-        <li><a href="#uncalibrated-magnetometer-xBias"><span class="secno">5.2.7</span> <span class="content">UncalibratedMagnetometer.xBias</span></a>
-        <li><a href="#uncalibrated-magnetometer-yBias"><span class="secno">5.2.8</span> <span class="content">UncalibratedMagnetometer.yBias</span></a>
-        <li><a href="#uncalibrated-magnetometer-zBias"><span class="secno">5.2.9</span> <span class="content">UncalibratedMagnetometer.zBias</span></a>
+        <li><a href="#uncalibrated-magnetometer-x"><span class="secno">5.2.1</span> <span class="content">UncalibratedMagnetometer.x</span></a>
+        <li><a href="#uncalibrated-magnetometer-y"><span class="secno">5.2.2</span> <span class="content">UncalibratedMagnetometer.y</span></a>
+        <li><a href="#uncalibrated-magnetometer-z"><span class="secno">5.2.3</span> <span class="content">UncalibratedMagnetometer.z</span></a>
+        <li><a href="#uncalibrated-magnetometer-xBias"><span class="secno">5.2.4</span> <span class="content">UncalibratedMagnetometer.xBias</span></a>
+        <li><a href="#uncalibrated-magnetometer-yBias"><span class="secno">5.2.5</span> <span class="content">UncalibratedMagnetometer.yBias</span></a>
+        <li><a href="#uncalibrated-magnetometer-zBias"><span class="secno">5.2.6</span> <span class="content">UncalibratedMagnetometer.zBias</span></a>
        </ol>
      </ol>
-    <li><a href="#limitations-magnetometer"><span class="secno">6</span> <span class="content">Limitations of Magnetometer Sensors</span></a>
-    <li><a href="#usecases-and-requirements"><span class="secno">7</span> <span class="content">Use Cases and Requirements</span></a>
-    <li><a href="#compass"><span class="secno">8</span> <span class="content">Compass Heading Using Magnetometers</span></a>
-    <li><a href="#acknowledgements"><span class="secno">9</span> <span class="content">Acknowledgements</span></a>
-    <li><a href="#conformance"><span class="secno">10</span> <span class="content">Conformance</span></a>
+    <li>
+     <a href="#abstract-opertaions"><span class="secno">6</span> <span class="content">Abstract Operations</span></a>
+     <ol class="toc">
+      <li><a href="#construct-a-magnetometer-object"><span class="secno">6.1</span> <span class="content">Construct a magnetometer object</span></a>
+     </ol>
+    <li><a href="#limitations-magnetometer"><span class="secno">7</span> <span class="content">Limitations of Magnetometer Sensors</span></a>
+    <li><a href="#usecases-and-requirements"><span class="secno">8</span> <span class="content">Use Cases and Requirements</span></a>
+    <li><a href="#compass"><span class="secno">9</span> <span class="content">Compass Heading Using Magnetometers</span></a>
+    <li><a href="#acknowledgements"><span class="secno">10</span> <span class="content">Acknowledgements</span></a>
+    <li><a href="#conformance"><span class="secno">11</span> <span class="content">Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1596,21 +1607,40 @@ API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a
    <p>For uncalibrated magnetometer, the <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading①">latest reading</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">values</a> contain <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field②">uncalibrated magnetic field</a> around the 3 different axes,
 and three additional <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry②">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key②">keys</a> are "xBias", "yBias", "zBias" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value②">values</a> contain the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion③">hard iron distortion</a> correction around the 3 different axes.</p>
    <p>The sign of the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑧">magnetic field</a> values must be according to the
-right-hand convention in a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by the device.</p>
-   <p class="note" role="note"><span>Note:</span> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local-coordinate-system">local coordinate system</dfn> of a mobile device is usually defined relative to
-the device’s screen when the device in its default orientation (see figure below).</p>
-   <p><img alt="Magnetometer coordinate system." src="images/magnetometer_coordinate_system.png" srcset="images/magnetometer_coordinate_system.svg"></p>
+right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> (see figure below).</p>
+   <p><img alt="Magnetometer coordinate system." onerror="this.src=&apos;images/magnetometer_coordinate_system.png&apos;" src="images/magnetometer_coordinate_system.svg" style="display: block;margin: auto;"></p>
+   <h3 class="heading settled" data-level="4.1" id="reference-frame"><span class="secno">4.1. </span><span class="content">Reference Frame</span><a class="self-link" href="#reference-frame"></a></h3>
+   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> represents the reference frame for the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer③">Magnetometer</a></code> and the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer③">UncalibratedMagnetometer</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-readings" id="ref-for-sensor-readings">readings</a>.
+It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="magnetometer-interface"><span class="secno">5.1. </span><span class="content">The Magnetometer Interface</span><a class="self-link" href="#magnetometer-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Magnetometer" data-dfn-type="constructor" data-export="" data-lt="Magnetometer(sensorOptions)|Magnetometer()" id="dom-magnetometer-magnetometer"><code>Constructor</code><a class="self-link" href="#dom-magnetometer-magnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Magnetometer/Magnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Magnetometer" data-dfn-type="constructor" data-export="" data-lt="Magnetometer(sensorOptions)|Magnetometer()" id="dom-magnetometer-magnetometer"><code>Constructor</code><a class="self-link" href="#dom-magnetometer-magnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-magnetometersensoroptions" id="ref-for-dictdef-magnetometersensoroptions">MagnetometerSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Magnetometer/Magnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>,
+  <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="magnetometer"><code>Magnetometer</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-magnetometer-x"><code>x</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-magnetometer-y"><code>y</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Magnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-magnetometer-z"><code>z</code></dfn>;
 };
+
+<span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-localcoordinatesystem"><code>LocalCoordinateSystem</code></dfn> { <dfn class="s idl-code" data-dfn-for="LocalCoordinateSystem" data-dfn-type="enum-value" data-export="" data-lt="&quot;device&quot;|device" id="dom-localcoordinatesystem-device"><code>"device"</code><a class="self-link" href="#dom-localcoordinatesystem-device"></a></dfn>, <dfn class="s idl-code" data-dfn-for="LocalCoordinateSystem" data-dfn-type="enum-value" data-export="" data-lt="&quot;screen&quot;|screen" id="dom-localcoordinatesystem-screen"><code>"screen"</code><a class="self-link" href="#dom-localcoordinatesystem-screen"></a></dfn> };
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-magnetometersensoroptions"><code>MagnetometerSensorOptions</code></dfn> :  <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a>  {
+  <a class="n" data-link-type="idl-name" href="#enumdef-localcoordinatesystem" id="ref-for-enumdef-localcoordinatesystem">LocalCoordinateSystem</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;device&quot;" data-dfn-for="MagnetometerSensorOptions" data-dfn-type="dict-member" data-export="" data-type="LocalCoordinateSystem " id="dom-magnetometersensoroptions-referenceframe"><code>referenceFrame</code></dfn> = "device";
+};
 </pre>
+   <p>To construct a <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer④">Magnetometer</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-a-magnetometer-object" id="ref-for-construct-a-magnetometer-object">construct a magnetometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑤">Magnetometer</a></code> interface.</p>
+   <h4 class="heading settled" data-level="5.1.1" id="magnetometer-x"><span class="secno">5.1.1. </span><span class="content">Magnetometer.x</span><a class="self-link" href="#magnetometer-x"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑥">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑨">magnetic field</a> around X-axis.
+In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <code>this</code> and "x" as arguments.</p>
+   <h4 class="heading settled" data-level="5.1.2" id="magnetometer-y"><span class="secno">5.1.2. </span><span class="content">Magnetometer.y</span><a class="self-link" href="#magnetometer-y"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-y" id="ref-for-dom-magnetometer-y">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑦">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field①⓪">magnetic field</a> around Y-axis.
+In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading①">get value from latest reading</a> with <code>this</code> and "y" as arguments.</p>
+   <h4 class="heading settled" data-level="5.1.3" id="magnetometer-z"><span class="secno">5.1.3. </span><span class="content">Magnetometer.z</span><a class="self-link" href="#magnetometer-z"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-z" id="ref-for-dom-magnetometer-z">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑧">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field①①">magnetic field</a> around Z-axis.
+In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading②">get value from latest reading</a> with <code>this</code> and "z" as arguments.</p>
    <h3 class="heading settled" data-level="5.2" id="uncalibrated-magnetometer-interface"><span class="secno">5.2. </span><span class="content">The UncalibratedMagnetometer Interface</span><a class="self-link" href="#uncalibrated-magnetometer-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="constructor" data-export="" data-lt="UncalibratedMagnetometer(sensorOptions)|UncalibratedMagnetometer()" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><code>Constructor</code><a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer/UncalibratedMagnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="constructor" data-export="" data-lt="UncalibratedMagnetometer(sensorOptions)|UncalibratedMagnetometer()" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><code>Constructor</code><a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-magnetometersensoroptions" id="ref-for-dictdef-magnetometersensoroptions①">MagnetometerSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="UncalibratedMagnetometer/UncalibratedMagnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>,
+  <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="uncalibratedmagnetometer"><code>UncalibratedMagnetometer</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor③">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-uncalibratedmagnetometer-x"><code>x</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-uncalibratedmagnetometer-y"><code>y</code></dfn>;
@@ -1620,35 +1650,50 @@ the device’s screen when the device in its default orientation (see figure bel
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UncalibratedMagnetometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-uncalibratedmagnetometer-zbias"><code>zBias</code></dfn>;
 };
 </pre>
-   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-magnetometer-object">Construct a Magnetometer Object<a class="self-link" href="#construct-a-magnetometer-object"></a></dfn>, or to <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-uncalibratedmagnetometer-object">Construct an UncalibratedMagnetometer Object<a class="self-link" href="#construct-an-uncalibratedmagnetometer-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
-   <h4 class="heading settled" data-level="5.2.1" id="magnetometer-x"><span class="secno">5.2.1. </span><span class="content">Magnetometer.x</span><a class="self-link" href="#magnetometer-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer③">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑨">magnetic field</a> around X-axis.
-In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <code>this</code> and "x" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.2" id="magnetometer-y"><span class="secno">5.2.2. </span><span class="content">Magnetometer.y</span><a class="self-link" href="#magnetometer-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-y" id="ref-for-dom-magnetometer-y">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer④">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field①⓪">magnetic field</a> around Y-axis.
-In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading①">get value from latest reading</a> with <code>this</code> and "y" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.3" id="magnetometer-z"><span class="secno">5.2.3. </span><span class="content">Magnetometer.z</span><a class="self-link" href="#magnetometer-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-z" id="ref-for-dom-magnetometer-z">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑤">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field①①">magnetic field</a> around Z-axis.
-In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading②">get value from latest reading</a> with <code>this</code> and "z" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.4" id="uncalibrated-magnetometer-x"><span class="secno">5.2.4. </span><span class="content">UncalibratedMagnetometer.x</span><a class="self-link" href="#uncalibrated-magnetometer-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-x" id="ref-for-dom-uncalibratedmagnetometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer③">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field③">uncalibrated magnetic field</a> around X-axis.
+   <p>To construct an <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer④">UncalibratedMagnetometer</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-a-magnetometer-object" id="ref-for-construct-a-magnetometer-object①">construct a magnetometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑤">UncalibratedMagnetometer</a></code> interface.</p>
+   <h4 class="heading settled" data-level="5.2.1" id="uncalibrated-magnetometer-x"><span class="secno">5.2.1. </span><span class="content">UncalibratedMagnetometer.x</span><a class="self-link" href="#uncalibrated-magnetometer-x"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-x" id="ref-for-dom-uncalibratedmagnetometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑥">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field③">uncalibrated magnetic field</a> around X-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <code>this</code> and "x" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.5" id="uncalibrated-magnetometer-y"><span class="secno">5.2.5. </span><span class="content">UncalibratedMagnetometer.y</span><a class="self-link" href="#uncalibrated-magnetometer-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-y" id="ref-for-dom-uncalibratedmagnetometer-y">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer④">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field④">uncalibrated magnetic field</a> around Y-axis.
+   <h4 class="heading settled" data-level="5.2.2" id="uncalibrated-magnetometer-y"><span class="secno">5.2.2. </span><span class="content">UncalibratedMagnetometer.y</span><a class="self-link" href="#uncalibrated-magnetometer-y"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-y" id="ref-for-dom-uncalibratedmagnetometer-y">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑦">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field④">uncalibrated magnetic field</a> around Y-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading④">get value from latest reading</a> with <code>this</code> and "y" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.6" id="uncalibrated-magnetometer-z"><span class="secno">5.2.6. </span><span class="content">UncalibratedMagnetometer.z</span><a class="self-link" href="#uncalibrated-magnetometer-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-z" id="ref-for-dom-uncalibratedmagnetometer-z">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑤">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field⑤">uncalibrated magnetic field</a> around Z-axis.
+   <h4 class="heading settled" data-level="5.2.3" id="uncalibrated-magnetometer-z"><span class="secno">5.2.3. </span><span class="content">UncalibratedMagnetometer.z</span><a class="self-link" href="#uncalibrated-magnetometer-z"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-z" id="ref-for-dom-uncalibratedmagnetometer-z">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑧">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field⑤">uncalibrated magnetic field</a> around Z-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading⑤">get value from latest reading</a> with <code>this</code> and "z" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.7" id="uncalibrated-magnetometer-xBias"><span class="secno">5.2.7. </span><span class="content">UncalibratedMagnetometer.xBias</span><a class="self-link" href="#uncalibrated-magnetometer-xBias"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-xbias" id="ref-for-dom-uncalibratedmagnetometer-xbias">xBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑥">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion④">hard iron distortion</a> correction around X-axis.
+   <h4 class="heading settled" data-level="5.2.4" id="uncalibrated-magnetometer-xBias"><span class="secno">5.2.4. </span><span class="content">UncalibratedMagnetometer.xBias</span><a class="self-link" href="#uncalibrated-magnetometer-xBias"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-xbias" id="ref-for-dom-uncalibratedmagnetometer-xbias">xBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑨">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion④">hard iron distortion</a> correction around X-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading⑥">get value from latest reading</a> with <code>this</code> and "xBias" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.8" id="uncalibrated-magnetometer-yBias"><span class="secno">5.2.8. </span><span class="content">UncalibratedMagnetometer.yBias</span><a class="self-link" href="#uncalibrated-magnetometer-yBias"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-ybias" id="ref-for-dom-uncalibratedmagnetometer-ybias">yBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑦">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion⑤">hard iron distortion</a> correction around Y-axis.
+   <h4 class="heading settled" data-level="5.2.5" id="uncalibrated-magnetometer-yBias"><span class="secno">5.2.5. </span><span class="content">UncalibratedMagnetometer.yBias</span><a class="self-link" href="#uncalibrated-magnetometer-yBias"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-ybias" id="ref-for-dom-uncalibratedmagnetometer-ybias">yBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer①⓪">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion⑤">hard iron distortion</a> correction around Y-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading⑦">get value from latest reading</a> with <code>this</code> and "yBias" as arguments.</p>
-   <h4 class="heading settled" data-level="5.2.9" id="uncalibrated-magnetometer-zBias"><span class="secno">5.2.9. </span><span class="content">UncalibratedMagnetometer.zBias</span><a class="self-link" href="#uncalibrated-magnetometer-zBias"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-zbias" id="ref-for-dom-uncalibratedmagnetometer-zbias">zBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑧">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion⑥">hard iron distortion</a> correction around Z-axis.
+   <h4 class="heading settled" data-level="5.2.6" id="uncalibrated-magnetometer-zBias"><span class="secno">5.2.6. </span><span class="content">UncalibratedMagnetometer.zBias</span><a class="self-link" href="#uncalibrated-magnetometer-zBias"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-zbias" id="ref-for-dom-uncalibratedmagnetometer-zbias">zBias</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer①①">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion⑥">hard iron distortion</a> correction around Z-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading⑧">get value from latest reading</a> with <code>this</code> and "zBias" as arguments.</p>
-   <h2 class="heading settled" data-level="6" id="limitations-magnetometer"><span class="secno">6. </span><span class="content">Limitations of Magnetometer Sensors</span><a class="self-link" href="#limitations-magnetometer"></a></h2>
+   <h2 class="heading settled" data-level="6" id="abstract-opertaions"><span class="secno">6. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-opertaions"></a></h2>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="6.1" data-lt="Construct a magnetometer object" data-noexport="" id="construct-a-magnetometer-object"><span class="secno">6.1. </span><span class="content">Construct a magnetometer object</span></h3>
+   <div class="algorithm" data-algorithm="construct a magnetometer object">
+    <dl>
+     <dt data-md="">input
+     <dd data-md="">
+      <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-magnetometersensoroptions" id="ref-for-dictdef-magnetometersensoroptions②">MagnetometerSensorOptions</a></code> object.</p>
+     <dt data-md="">output
+     <dd data-md="">
+      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor④">Sensor</a></code> object.</p>
+    </dl>
+    <ol>
+     <li data-md="">
+      <p>Let <var>sensor_instance</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> with <var>options</var>.</p>
+     <li data-md="">
+      <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-magnetometersensoroptions-referenceframe" id="ref-for-dom-magnetometersensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
+      <ol>
+       <li data-md="">
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
+      </ol>
+     <li data-md="">
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a>.</p>
+    </ol>
+   </div>
+   <h2 class="heading settled" data-level="7" id="limitations-magnetometer"><span class="secno">7. </span><span class="content">Limitations of Magnetometer Sensors</span><a class="self-link" href="#limitations-magnetometer"></a></h2>
    <p><em>This section is non-normative</em>.</p>
    <p>The direction and magnitude of the Earth’s field changes with location, latitude in particular. For example,
 the magnitude is lowest near the equator and highest near the poles.
@@ -1658,7 +1703,7 @@ Presence of electronic items, laptops, batteries, etc also contribute to the sof
 Flight Mode option in mobile phones might help in decreasing the electro magnetic interference.</p>
    <p>In addition to the above spatial variations of the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field①②">magnetic field</a>, time based variations,
 like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the earth.</p>
-   <h2 class="heading settled" data-level="7" id="usecases-and-requirements"><span class="secno">7. </span><span class="content">Use Cases and Requirements</span><a class="self-link" href="#usecases-and-requirements"></a></h2>
+   <h2 class="heading settled" data-level="8" id="usecases-and-requirements"><span class="secno">8. </span><span class="content">Use Cases and Requirements</span><a class="self-link" href="#usecases-and-requirements"></a></h2>
    <p>Magnetometers can be used for a variety of use-cases, such as:</p>
    <ul>
     <li data-md="">
@@ -1675,13 +1720,13 @@ are some of the use cases.</p>
     <li data-md="">
      <p>Indoor navigation system may use magnetometer on mobile phones <a data-link-type="biblio" href="#biblio-magindoorpos">[MAGINDOORPOS]</a>. Specific use cases for indoor navigation may include proximity advertising, way finding in malls or airports, geofencing, etc.</p>
     <li data-md="">
-     <p>Calculating compass heading, more on that in <a href="#compass">§8 Compass Heading Using Magnetometers</a>.</p>
+     <p>Calculating compass heading, more on that in <a href="#compass">§9 Compass Heading Using Magnetometers</a>.</p>
    </ul>
    <p>Metal detection and input using magnetic button may require only coarse data and low sampling rates suffice.
 Gesture recognition or indoor navigation are more real time use cases where there might be a need for more accurate sensor readings and higher sampling rates.
 Head mount tracking in Virtual Reality may require sensor fusion from accelerometer, gyroscope and magnetometer. Magnetometer data may be used to help in calibration of gyroscope readings
 and align yaw readings with the magnetic north. The required sampling rate might depend on the sensor fusion algorithm and characteristics of other motion sensors involved.</p>
-   <h2 class="heading settled" data-level="8" id="compass"><span class="secno">8. </span><span class="content">Compass Heading Using Magnetometers</span><a class="self-link" href="#compass"></a></h2>
+   <h2 class="heading settled" data-level="9" id="compass"><span class="secno">9. </span><span class="content">Compass Heading Using Magnetometers</span><a class="self-link" href="#compass"></a></h2>
    <p>Compasses, instruments that align themselves with the magnetic poles of the Earth, have been used in navigation for centuries.
 The earth’s rotational axis defines the geographic north and south poles that we use for
 map references. It turns out that there is a discrepancy of around 11.5 degrees (around 1000 miles) between the geographic poles and the
@@ -1722,9 +1767,9 @@ to apply various tilt compensation techniques for which she needs a 3-axis
 accelerometer. Data from the orientation sensor, which is a fusion of the
 accelerometer and magnetometer sensors, is required to implement this
 particular use case.</p>
-   <h2 class="heading settled" data-level="9" id="acknowledgements"><span class="secno">9. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
+   <h2 class="heading settled" data-level="10" id="acknowledgements"><span class="secno">10. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API.</p>
-   <h2 class="heading settled" data-level="10" id="conformance"><span class="secno">10. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <h2 class="heading settled" data-level="11" id="conformance"><span class="secno">11. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
    <p>Conformance requirements are expressed with a combination of
 descriptive assertions and RFC 2119 terminology. The key words "MUST",
 "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
@@ -1744,13 +1789,14 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#calibrated-magnetic-field">calibrated magnetic field</a><span>, in §1</span>
-   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §10</span>
-   <li><a href="#construct-a-magnetometer-object">Construct a Magnetometer Object</a><span>, in §5.2</span>
-   <li><a href="#construct-an-uncalibratedmagnetometer-object">Construct an UncalibratedMagnetometer Object</a><span>, in §5.2</span>
-   <li><a href="#declination-angle">declination angle</a><span>, in §8</span>
+   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §11</span>
+   <li><a href="#construct-a-magnetometer-object">Construct a magnetometer object</a><span>, in §6</span>
+   <li><a href="#declination-angle">declination angle</a><span>, in §9</span>
+   <li><a href="#dom-localcoordinatesystem-device">device</a><span>, in §5.1</span>
+   <li><a href="#dom-localcoordinatesystem-device">"device"</a><span>, in §5.1</span>
    <li><a href="#hard-iron-distortion">Hard iron distortion</a><span>, in §1</span>
-   <li><a href="#local-coordinate-system">local coordinate system</a><span>, in §4</span>
-   <li><a href="#magnetic-declination">Magnetic declination</a><span>, in §8</span>
+   <li><a href="#enumdef-localcoordinatesystem">LocalCoordinateSystem</a><span>, in §5.1</span>
+   <li><a href="#magnetic-declination">Magnetic declination</a><span>, in §9</span>
    <li><a href="#magnetic-field">magnetic field</a><span>, in §1</span>
    <li><a href="#dom-magnetometer-magnetometer">Magnetometer()</a><span>, in §5.1</span>
    <li>
@@ -1759,7 +1805,11 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="#magnetometer-sensor-type">definition of</a><span>, in §4</span>
      <li><a href="#magnetometer">(interface)</a><span>, in §5.1</span>
     </ul>
+   <li><a href="#dictdef-magnetometersensoroptions">MagnetometerSensorOptions</a><span>, in §5.1</span>
    <li><a href="#dom-magnetometer-magnetometer">Magnetometer(sensorOptions)</a><span>, in §5.1</span>
+   <li><a href="#dom-magnetometersensoroptions-referenceframe">referenceFrame</a><span>, in §5.1</span>
+   <li><a href="#dom-localcoordinatesystem-screen">"screen"</a><span>, in §5.1</span>
+   <li><a href="#dom-localcoordinatesystem-screen">screen</a><span>, in §5.1</span>
    <li><a href="#soft-iron-distortion">Soft iron distortion</a><span>, in §1</span>
    <li><a href="#uncalibrated-magnetic-field">uncalibrated magnetic field</a><span>, in §1</span>
    <li><a href="#uncalibratedmagnetometer">UncalibratedMagnetometer</a><span>, in §5.2</span>
@@ -1790,6 +1840,12 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
+    <a data-link-type="biblio">[accelerometer]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/accelerometer#device-coordinate-system">device coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer#screen-coordinate-system">screen coordinate system</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
@@ -1798,8 +1854,10 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
      <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
      <li><a href="https://w3c.github.io/sensors/#limit-max-frequency">limit maximum sampling frequency</a>
+     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
      <li><a href="https://w3c.github.io/sensors#mitigation-strategies">mitigation strategies</a>
      <li><a href="https://w3c.github.io/sensors/#reduce-accuracy">reduce accuracy</a>
+     <li><a href="https://w3c.github.io/sensors#sensor-readings">sensor readings</a>
      <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
     </ul>
    <li>
@@ -1826,8 +1884,10 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-accelerometer">[ACCELEROMETER]
+   <dd>Anssi Kostiainen; Alexander Shalamov. <a href="https://www.w3.org/TR/accelerometer/">Accelerometer</a>. 18 October 2017. WD. URL: <a href="https://www.w3.org/TR/accelerometer/">https://www.w3.org/TR/accelerometer/</a>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
-   <dd>Rick Waldron; et al. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. 2 October 2017. WD. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
+   <dd>Rick Waldron; et al. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. 18 October 2017. WD. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-permissions">[PERMISSIONS]
@@ -1849,14 +1909,22 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd>Boris Smus. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=445926">Magnetic input for Google cardboard</a>. Informational. URL: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=445926">https://bugs.chromium.org/p/chromium/issues/detail?id=445926</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv" href="#dom-magnetometer-magnetometer"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a> <a class="nv" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<a class="nv" href="#dom-magnetometer-magnetometer"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-magnetometersensoroptions" id="ref-for-dictdef-magnetometersensoroptions③">MagnetometerSensorOptions</a> <a class="nv" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>,
+  <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#magnetometer"><code>Magnetometer</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②①">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑨"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-magnetometer-x"><code>x</code></a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-magnetometer-y"><code>y</code></a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-magnetometer-z"><code>z</code></a>;
 };
 
-[<a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①①">SensorOptions</a> <a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>]
+<span class="kt">enum</span> <a class="nv" href="#enumdef-localcoordinatesystem"><code>LocalCoordinateSystem</code></a> { <a class="s" href="#dom-localcoordinatesystem-device"><code>"device"</code></a>, <a class="s" href="#dom-localcoordinatesystem-screen"><code>"screen"</code></a> };
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-magnetometersensoroptions"><code>MagnetometerSensorOptions</code></a> :  <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a>  {
+  <a class="n" data-link-type="idl-name" href="#enumdef-localcoordinatesystem" id="ref-for-enumdef-localcoordinatesystem①">LocalCoordinateSystem</a> <a class="nv" data-default="&quot;device&quot;" data-type="LocalCoordinateSystem " href="#dom-magnetometersensoroptions-referenceframe"><code>referenceFrame</code></a> = "device";
+};
+
+[<a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-magnetometersensoroptions" id="ref-for-dictdef-magnetometersensoroptions①①">MagnetometerSensorOptions</a> <a class="nv" href="#dom-uncalibratedmagnetometer-uncalibratedmagnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>,
+  <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#uncalibratedmagnetometer"><code>UncalibratedMagnetometer</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor③①">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-uncalibratedmagnetometer-x"><code>x</code></a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-uncalibratedmagnetometer-y"><code>y</code></a>;
@@ -1872,10 +1940,10 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <ul>
     <li><a href="#ref-for-magnetic-field">1. Introduction</a> <a href="#ref-for-magnetic-field①">(2)</a> <a href="#ref-for-magnetic-field②">(3)</a> <a href="#ref-for-magnetic-field③">(4)</a> <a href="#ref-for-magnetic-field④">(5)</a> <a href="#ref-for-magnetic-field⑤">(6)</a> <a href="#ref-for-magnetic-field⑥">(7)</a>
     <li><a href="#ref-for-magnetic-field⑦">4. Model</a> <a href="#ref-for-magnetic-field⑧">(2)</a>
-    <li><a href="#ref-for-magnetic-field⑨">5.2.1. Magnetometer.x</a>
-    <li><a href="#ref-for-magnetic-field①⓪">5.2.2. Magnetometer.y</a>
-    <li><a href="#ref-for-magnetic-field①①">5.2.3. Magnetometer.z</a>
-    <li><a href="#ref-for-magnetic-field①②">6. Limitations of Magnetometer Sensors</a>
+    <li><a href="#ref-for-magnetic-field⑨">5.1.1. Magnetometer.x</a>
+    <li><a href="#ref-for-magnetic-field①⓪">5.1.2. Magnetometer.y</a>
+    <li><a href="#ref-for-magnetic-field①①">5.1.3. Magnetometer.z</a>
+    <li><a href="#ref-for-magnetic-field①②">7. Limitations of Magnetometer Sensors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="hard-iron-distortion">
@@ -1883,9 +1951,9 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <ul>
     <li><a href="#ref-for-hard-iron-distortion">1. Introduction</a> <a href="#ref-for-hard-iron-distortion①">(2)</a>
     <li><a href="#ref-for-hard-iron-distortion②">4. Model</a> <a href="#ref-for-hard-iron-distortion③">(2)</a>
-    <li><a href="#ref-for-hard-iron-distortion④">5.2.7. UncalibratedMagnetometer.xBias</a>
-    <li><a href="#ref-for-hard-iron-distortion⑤">5.2.8. UncalibratedMagnetometer.yBias</a>
-    <li><a href="#ref-for-hard-iron-distortion⑥">5.2.9. UncalibratedMagnetometer.zBias</a>
+    <li><a href="#ref-for-hard-iron-distortion④">5.2.4. UncalibratedMagnetometer.xBias</a>
+    <li><a href="#ref-for-hard-iron-distortion⑤">5.2.5. UncalibratedMagnetometer.yBias</a>
+    <li><a href="#ref-for-hard-iron-distortion⑥">5.2.6. UncalibratedMagnetometer.zBias</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="soft-iron-distortion">
@@ -1905,9 +1973,9 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <ul>
     <li><a href="#ref-for-uncalibrated-magnetic-field">1. Introduction</a>
     <li><a href="#ref-for-uncalibrated-magnetic-field①">4. Model</a> <a href="#ref-for-uncalibrated-magnetic-field②">(2)</a>
-    <li><a href="#ref-for-uncalibrated-magnetic-field③">5.2.4. UncalibratedMagnetometer.x</a>
-    <li><a href="#ref-for-uncalibrated-magnetic-field④">5.2.5. UncalibratedMagnetometer.y</a>
-    <li><a href="#ref-for-uncalibrated-magnetic-field⑤">5.2.6. UncalibratedMagnetometer.z</a>
+    <li><a href="#ref-for-uncalibrated-magnetic-field③">5.2.1. UncalibratedMagnetometer.x</a>
+    <li><a href="#ref-for-uncalibrated-magnetic-field④">5.2.2. UncalibratedMagnetometer.y</a>
+    <li><a href="#ref-for-uncalibrated-magnetic-field⑤">5.2.3. UncalibratedMagnetometer.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="magnetometer-sensor-type">
@@ -1916,40 +1984,56 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-magnetometer-sensor-type">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-coordinate-system">
-   <b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-local-coordinate-system">4. Model</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="magnetometer">
    <b><a href="#magnetometer">#magnetometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer">1. Introduction</a>
     <li><a href="#ref-for-magnetometer①">4. Model</a> <a href="#ref-for-magnetometer②">(2)</a>
-    <li><a href="#ref-for-magnetometer③">5.2.1. Magnetometer.x</a>
-    <li><a href="#ref-for-magnetometer④">5.2.2. Magnetometer.y</a>
-    <li><a href="#ref-for-magnetometer⑤">5.2.3. Magnetometer.z</a>
+    <li><a href="#ref-for-magnetometer③">4.1. Reference Frame</a>
+    <li><a href="#ref-for-magnetometer④">5.1. The Magnetometer Interface</a> <a href="#ref-for-magnetometer⑤">(2)</a>
+    <li><a href="#ref-for-magnetometer⑥">5.1.1. Magnetometer.x</a>
+    <li><a href="#ref-for-magnetometer⑦">5.1.2. Magnetometer.y</a>
+    <li><a href="#ref-for-magnetometer⑧">5.1.3. Magnetometer.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-magnetometer-x">
    <b><a href="#dom-magnetometer-x">#dom-magnetometer-x</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-magnetometer-x">5.2.1. Magnetometer.x</a>
-    <li><a href="#ref-for-dom-magnetometer-x①">8. Compass Heading Using Magnetometers</a>
+    <li><a href="#ref-for-dom-magnetometer-x">5.1.1. Magnetometer.x</a>
+    <li><a href="#ref-for-dom-magnetometer-x①">9. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-magnetometer-y">
    <b><a href="#dom-magnetometer-y">#dom-magnetometer-y</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-magnetometer-y">5.2.2. Magnetometer.y</a>
-    <li><a href="#ref-for-dom-magnetometer-y①">8. Compass Heading Using Magnetometers</a>
+    <li><a href="#ref-for-dom-magnetometer-y">5.1.2. Magnetometer.y</a>
+    <li><a href="#ref-for-dom-magnetometer-y①">9. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-magnetometer-z">
    <b><a href="#dom-magnetometer-z">#dom-magnetometer-z</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-magnetometer-z">5.2.3. Magnetometer.z</a>
+    <li><a href="#ref-for-dom-magnetometer-z">5.1.3. Magnetometer.z</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-localcoordinatesystem">
+   <b><a href="#enumdef-localcoordinatesystem">#enumdef-localcoordinatesystem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-localcoordinatesystem">5.1. The Magnetometer Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-magnetometersensoroptions">
+   <b><a href="#dictdef-magnetometersensoroptions">#dictdef-magnetometersensoroptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-magnetometersensoroptions">5.1. The Magnetometer Interface</a>
+    <li><a href="#ref-for-dictdef-magnetometersensoroptions①">5.2. The UncalibratedMagnetometer Interface</a>
+    <li><a href="#ref-for-dictdef-magnetometersensoroptions②">6.1. Construct a magnetometer object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-magnetometersensoroptions-referenceframe">
+   <b><a href="#dom-magnetometersensoroptions-referenceframe">#dom-magnetometersensoroptions-referenceframe</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-magnetometersensoroptions-referenceframe">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="uncalibratedmagnetometer">
@@ -1957,60 +2041,69 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <ul>
     <li><a href="#ref-for-uncalibratedmagnetometer">1. Introduction</a>
     <li><a href="#ref-for-uncalibratedmagnetometer①">4. Model</a> <a href="#ref-for-uncalibratedmagnetometer②">(2)</a>
-    <li><a href="#ref-for-uncalibratedmagnetometer③">5.2.4. UncalibratedMagnetometer.x</a>
-    <li><a href="#ref-for-uncalibratedmagnetometer④">5.2.5. UncalibratedMagnetometer.y</a>
-    <li><a href="#ref-for-uncalibratedmagnetometer⑤">5.2.6. UncalibratedMagnetometer.z</a>
-    <li><a href="#ref-for-uncalibratedmagnetometer⑥">5.2.7. UncalibratedMagnetometer.xBias</a>
-    <li><a href="#ref-for-uncalibratedmagnetometer⑦">5.2.8. UncalibratedMagnetometer.yBias</a>
-    <li><a href="#ref-for-uncalibratedmagnetometer⑧">5.2.9. UncalibratedMagnetometer.zBias</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer③">4.1. Reference Frame</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer④">5.2. The UncalibratedMagnetometer Interface</a> <a href="#ref-for-uncalibratedmagnetometer⑤">(2)</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer⑥">5.2.1. UncalibratedMagnetometer.x</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer⑦">5.2.2. UncalibratedMagnetometer.y</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer⑧">5.2.3. UncalibratedMagnetometer.z</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer⑨">5.2.4. UncalibratedMagnetometer.xBias</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer①⓪">5.2.5. UncalibratedMagnetometer.yBias</a>
+    <li><a href="#ref-for-uncalibratedmagnetometer①①">5.2.6. UncalibratedMagnetometer.zBias</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-x">
    <b><a href="#dom-uncalibratedmagnetometer-x">#dom-uncalibratedmagnetometer-x</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-uncalibratedmagnetometer-x">5.2.4. UncalibratedMagnetometer.x</a>
+    <li><a href="#ref-for-dom-uncalibratedmagnetometer-x">5.2.1. UncalibratedMagnetometer.x</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-y">
    <b><a href="#dom-uncalibratedmagnetometer-y">#dom-uncalibratedmagnetometer-y</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-uncalibratedmagnetometer-y">5.2.5. UncalibratedMagnetometer.y</a>
+    <li><a href="#ref-for-dom-uncalibratedmagnetometer-y">5.2.2. UncalibratedMagnetometer.y</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-z">
    <b><a href="#dom-uncalibratedmagnetometer-z">#dom-uncalibratedmagnetometer-z</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-uncalibratedmagnetometer-z">5.2.6. UncalibratedMagnetometer.z</a>
+    <li><a href="#ref-for-dom-uncalibratedmagnetometer-z">5.2.3. UncalibratedMagnetometer.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-xbias">
    <b><a href="#dom-uncalibratedmagnetometer-xbias">#dom-uncalibratedmagnetometer-xbias</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-uncalibratedmagnetometer-xbias">5.2.7. UncalibratedMagnetometer.xBias</a>
+    <li><a href="#ref-for-dom-uncalibratedmagnetometer-xbias">5.2.4. UncalibratedMagnetometer.xBias</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-ybias">
    <b><a href="#dom-uncalibratedmagnetometer-ybias">#dom-uncalibratedmagnetometer-ybias</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-uncalibratedmagnetometer-ybias">5.2.8. UncalibratedMagnetometer.yBias</a>
+    <li><a href="#ref-for-dom-uncalibratedmagnetometer-ybias">5.2.5. UncalibratedMagnetometer.yBias</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-zbias">
    <b><a href="#dom-uncalibratedmagnetometer-zbias">#dom-uncalibratedmagnetometer-zbias</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-uncalibratedmagnetometer-zbias">5.2.9. UncalibratedMagnetometer.zBias</a>
+    <li><a href="#ref-for-dom-uncalibratedmagnetometer-zbias">5.2.6. UncalibratedMagnetometer.zBias</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="construct-a-magnetometer-object">
+   <b><a href="#construct-a-magnetometer-object">#construct-a-magnetometer-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-construct-a-magnetometer-object">5.1. The Magnetometer Interface</a>
+    <li><a href="#ref-for-construct-a-magnetometer-object①">5.2. The UncalibratedMagnetometer Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="magnetic-declination">
    <b><a href="#magnetic-declination">#magnetic-declination</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-magnetic-declination">8. Compass Heading Using Magnetometers</a>
+    <li><a href="#ref-for-magnetic-declination">9. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="declination-angle">
    <b><a href="#declination-angle">#declination-angle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-declination-angle">8. Compass Heading Using Magnetometers</a> <a href="#ref-for-declination-angle①">(2)</a>
+    <li><a href="#ref-for-declination-angle">9. Compass Heading Using Magnetometers</a> <a href="#ref-for-declination-angle①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
Introduce MagnetometerSensorOptions that can control whether screen
or device coordinate system is used.

This patch is a part of fix for https://github.com/w3c/sensors/issues/257


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alexshalamov/magnetometer/pull/39.html" title="Last updated on Feb 8, 2018, 12:44 PM GMT (66905ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/39/7dbf5d6...alexshalamov:66905ee.html" title="Last updated on Feb 8, 2018, 12:44 PM GMT (66905ee)">Diff</a>