### PR TITLE
Editorial pass, update informative references, fix broken links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -42,6 +42,9 @@ urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
   type: dfn
     text: device coordinate system
     text: screen coordinate system
+urlPrefix: https://w3c.github.io/motion-sensors/; spec: MOTIONSENSORS
+  type: dfn
+    text: Absolute Orientation Sensor; url: absolute-orientation
 </pre>
 
 
@@ -371,21 +374,19 @@ Use Cases and Requirements {#usecases-and-requirements}
 
 <em>This section is non-normative</em>.
 
-Magnetometers can be used for a variety of use-cases, such as:
+Magnetometers can be used for a variety of use-cases, for example:
 
-- Metal detector web application.
-- Providing input using magnetic button for VR enclosures [[VRBUTTON]].
-- Gesture recognition based on magnetic field. Various interactions like writing, signing and playing an instrument can also be enabled using a magnet like a rod, pen or a ring [[MAGITACT]].
+- Sensor fusion. A common use-case for magnetometers is sensor fusion in order to generate an <a>Absolute Orientation Sensor</a> [[MOTION-SENSORS]] which is stationary to the Earth plane, or a compass, which is basically the former with corrections to the declination depending on geolocation position, such that it points to the true north. Calculating compass heading as detailed in [[#compass]].
+- Virtual Reality and Augmented Reality. Magnetometer can be used to implement input using magnetic button for VR enclosures [[VRBUTTON]]. Head-mount tracking systems for VR and AR can use magnetometer data to help in calibration of gyroscope readings and align yaw readings with the magnetic north.
+- Gesture recognition. Various interactions like writing, signing and playing an instrument can also be enabled using a magnet like a rod, pen or a ring [[MAGITACT]].
   The user makes coarse gestures in the 3D space around the device using the magnet. Movement of the magnet affects the magnetic field sensed by the compass sensor integrated in the device.
-  The temporal pattern of the gesture is then used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
+  The temporal pattern of the gesture can be used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
   are some of the use cases.
-- A common use-case for magnetometers is sensor fusion in order to generate an Orientation Sensor which is stationary to the Earth plane, or a compass, which is basically the former with corrections to the declination depending on geolocation position, such that it points to the true north.
-- Indoor navigation system can use magnetometer on mobile phones [[MAGINDOORPOS]]. Use cases for indoor navigation can include, for example, proximity advertising, way finding in malls or airports, and geofencing.
-- Calculating compass heading as detailed in [[#compass]].
-- Head mount tracking in Virtual Reality can use magnetometer data to help in calibration of gyroscope readings and align yaw readings with the magnetic north. 
+- Indoor navigation. Navigation systems can use magnetometer data on mobile devices [[MAGINDOORPOS]] to detect the magnetic field inside a building. With sufficient local variability, the anomalies can be utilized in self-localization. Use cases for indoor navigation include, for example, proximity advertising, way finding in malls or airports, and geofencing.
+- Metal detection. Magnetometers can be used by utility applications to detect the presence of metal nearby, e.g. finding inclusions hidden within objects.
 
 <div class="note">
-Requirements with respect to data coasrceness and sampling frequency can vary depending on the use case at hand. For example, metal detection or input using magnetic button can likely be implemented with coarser data and using lower sampling frequency compared to gesture recognition, indoor navigation, or VR use cases. In sensor fusion use cases, the sampling frequency that yeilds optimal results is dependent on e.g. sensor fusion algorithm and characteristics of other motion sensors involved.
+Requirements with respect to data coarseness and sampling frequency can vary depending on the use case at hand. For example, metal detection or input using magnetic button can likely be implemented with coarser data and using lower sampling frequency compared to gesture recognition, indoor navigation, or VR and AR use cases. In sensor fusion use cases, the sampling frequency that yeilds optimal results is dependent on e.g. sensor fusion algorithm and characteristics of other motion sensors involved.
 </div>
 
 Compass Heading Using Magnetometers {#compass}

--- a/index.bs
+++ b/index.bs
@@ -22,7 +22,7 @@ Inline Github Issues: true
 Boilerplate: omit issues-index, omit conformance
 </pre>
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
+urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
   type: dfn
     text: high-level
     text: sensor
@@ -33,12 +33,12 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: sensor type
     text: mitigation strategies; url: mitigation-strategies
     text: local coordinate system
-    text: sensor readings; url: sensor-readings
+    text: sensor readings; url: sensor-reading
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
     text: keystroke monitoring; url: keystroke-monitoring
     text: sensor permission name; url: sensor-permission-names
     text: supported sensor options
-urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
+urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
   type: dfn
     text: device coordinate system
     text: screen coordinate system
@@ -47,11 +47,6 @@ urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
 
 <pre class=biblio>
 {
-   "COMPASSHEADING": {
-    "title": "Compass Heading using Magnetometer",
-    "status": "Informational",
-    "href": "http://www51.honeywell.com/aero/common/documents/myaerospacecatalog-documents/Defense_Brochures-documents/Magnetic__Literature_Application_notes-documents/AN203_Compass_Heading_Using_Magnetometers.pdf"
-   },
    "MAGITACT": {
         "authors": [
             "Hamed Ketabdar, Kamer Ali Yüksel, Mehran Roshandel"
@@ -74,13 +69,13 @@ urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
     },
     "MAGINDOORPOS": {
         "authors": [
-            "IndoorAtlas"
+            "Janne Haverinen, Anssi Kemppainen"
         ],
         "id": "MAGINDOORPOS",
-        "href": "http://www.indooratlas.com/wp-content/uploads/2016/03/magnetic_positioning_opus_jun2014.pdf",
-        "title": "Indoor positioning using magnetometer",
+        "href": "https://doi.org/10.1016%2Fj.robot.2009.07.018",
+        "title": "Global indoor self-localization based on the ambient magnetic field",
         "status": "Informational",
-        "publisher": "Unknown"
+        "publisher": "Robotics and Autonomous Systems"
     }
 }
 </pre>
@@ -369,10 +364,12 @@ Presence of electronic items, laptops, batteries, etc also contribute to the sof
 Flight Mode option in mobile phones might help in decreasing the electro magnetic interference.
 
 In addition to the above spatial variations of the <a>magnetic field</a>, time based variations,
-like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the earth.
+like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the Earth.
 
 Use Cases and Requirements {#usecases-and-requirements}
 ===================
+
+<em>This section is non-normative</em>.
 
 Magnetometers can be used for a variety of use-cases, such as:
 
@@ -382,30 +379,32 @@ Magnetometers can be used for a variety of use-cases, such as:
   The user makes coarse gestures in the 3D space around the device using the magnet. Movement of the magnet affects the magnetic field sensed by the compass sensor integrated in the device.
   The temporal pattern of the gesture is then used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
   are some of the use cases.
-- In cases, where it is not possible to use orientation sensor, user may need to fuse magnetometer data with with other low-level sensor data, to calculate orientation.
-- Indoor navigation system may use magnetometer on mobile phones [[MAGINDOORPOS]]. Specific use cases for indoor navigation may include proximity advertising, way finding in malls or airports, geofencing, etc.
-- Calculating compass heading, more on that in [[#compass]].
+- A common use-case for magnetometers is sensor fusion in order to generate an Orientation Sensor which is stationary to the Earth plane, or a compass, which is basically the former with corrections to the declination depending on geolocation position, such that it points to the true north.
+- Indoor navigation system can use magnetometer on mobile phones [[MAGINDOORPOS]]. Use cases for indoor navigation can include, for example, proximity advertising, way finding in malls or airports, and geofencing.
+- Calculating compass heading as detailed in [[#compass]].
+- Head mount tracking in Virtual Reality can use magnetometer data to help in calibration of gyroscope readings and align yaw readings with the magnetic north. 
 
-Metal detection and input using magnetic button may require only coarse data and low sampling rates suffice.
-Gesture recognition or indoor navigation are more real time use cases where there might be a need for more accurate sensor readings and higher sampling rates.
-Head mount tracking in Virtual Reality may require sensor fusion from accelerometer, gyroscope and magnetometer. Magnetometer data may be used to help in calibration of gyroscope readings
-and align yaw readings with the magnetic north. The required sampling rate might depend on the sensor fusion algorithm and characteristics of other motion sensors involved.
+<div class="note">
+Requirements with respect to data coasrceness and sampling frequency can vary depending on the use case at hand. For example, metal detection or input using magnetic button can likely be implemented with coarser data and using lower sampling frequency compared to gesture recognition, indoor navigation, or VR use cases. In sensor fusion use cases, the sampling frequency that yeilds optimal results is dependent on e.g. sensor fusion algorithm and characteristics of other motion sensors involved.
+</div>
 
 Compass Heading Using Magnetometers {#compass}
 ======================
 
+<em>This section is non-normative</em>.
+
 Compasses, instruments that align themselves with the magnetic poles of the Earth, have been used in navigation for centuries.
-The earth’s rotational axis defines the geographic north and south poles that we use for
+The Earth’s rotational axis defines the geographic north and south poles that we use for
 map references. It turns out that there is a discrepancy of around 11.5 degrees (around 1000 miles) between the geographic poles and the
 magnetic poles. <a>Declination angle</a> is applied to the magnetic direction to correct for this situation.
 
-If the device is always level to the earth’s surface, compass heading [[COMPASSHEADING]] can be determined by using just the
-{{Magnetometer/x!!attribute}} and {{Magnetometer/y!!attribute}} component of the earth’s magnetic field, that
-is, the directions planar with the earth’s surface.
+If the device is always level to the Earth’s surface, compass heading can be determined by using just the
+{{Magnetometer/x!!attribute}} and {{Magnetometer/y!!attribute}} component of the Earth’s magnetic field, that
+is, the directions planar with the Earth’s surface.
 To determine geographic north (or true north) heading, add the appropriate <a>declination angle</a>.
 
 <dfn>Magnetic declination</dfn> or <dfn>declination angle</dfn> is the angle on the horizontal plane between magnetic north and the true north and depends on the position on the Earth's surface, and changes over time.
-By convention, declination is positive when magnetic north is east of true north, and negative when it is to the west. You can get real time value for <a>magnetic declination</a> e.g. using the <a href="http://www.ngdc.noaa.gov/geomag-web/calculators/declinationHelp">Magnetic declination calculator</a>
+By convention, declination is positive when magnetic north is east of true north, and negative when it is to the west. You can get real time value for <a>magnetic declination</a> e.g. using the <a href="https://www.ngdc.noaa.gov/geomag-web/calculators/declinationHelp">Magnetic declination calculator</a>
 provided by the National Oceanic and Atmospheric Administration (NOAA).
 
 The magnetic north is calculated as follows:
@@ -419,7 +418,7 @@ The magnetic north is calculated as follows:
   </pre>
 </div>
 
-The geographic north at a given latitude and longitude is calculated as follows:
+The geographic north at a given latitude and longitude can be calculated as follows:
 
 <div class="example">
   <pre highlight="js">

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
   <link href="https://www.w3.org/TR/magnetometer/" rel="canonical">
-  <meta content="f487f212b895ae62cd2412cf654910bc941abbe3" name="document-revision">
+  <meta content="94c48ff4c5258ec46bd345fd150255ad9fca02c5" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1432,7 +1432,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Magnetometer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-14">14 March 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-15">15 March 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1725,27 +1725,23 @@ Flight Mode option in mobile phones might help in decreasing the electro magneti
 like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the Earth.</p>
    <h2 class="heading settled" data-level="8" id="usecases-and-requirements"><span class="secno">8. </span><span class="content">Use Cases and Requirements</span><a class="self-link" href="#usecases-and-requirements"></a></h2>
    <p><em>This section is non-normative</em>.</p>
-   <p>Magnetometers can be used for a variety of use-cases, such as:</p>
+   <p>Magnetometers can be used for a variety of use-cases, for example:</p>
    <ul>
     <li data-md="">
-     <p>Metal detector web application.</p>
+     <p>Sensor fusion. A common use-case for magnetometers is sensor fusion in order to generate an <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors/#absolute-orientation" id="ref-for-absolute-orientation">Absolute Orientation Sensor</a> <a data-link-type="biblio" href="#biblio-motion-sensors">[MOTION-SENSORS]</a> which is stationary to the Earth plane, or a compass, which is basically the former with corrections to the declination depending on geolocation position, such that it points to the true north. Calculating compass heading as detailed in <a href="#compass">§9 Compass Heading Using Magnetometers</a>.</p>
     <li data-md="">
-     <p>Providing input using magnetic button for VR enclosures <a data-link-type="biblio" href="#biblio-vrbutton">[VRBUTTON]</a>.</p>
+     <p>Virtual Reality and Augmented Reality. Magnetometer can be used to implement input using magnetic button for VR enclosures <a data-link-type="biblio" href="#biblio-vrbutton">[VRBUTTON]</a>. Head-mount tracking systems for VR and AR can use magnetometer data to help in calibration of gyroscope readings and align yaw readings with the magnetic north.</p>
     <li data-md="">
-     <p>Gesture recognition based on magnetic field. Various interactions like writing, signing and playing an instrument can also be enabled using a magnet like a rod, pen or a ring <a data-link-type="biblio" href="#biblio-magitact">[MAGITACT]</a>.
+     <p>Gesture recognition. Various interactions like writing, signing and playing an instrument can also be enabled using a magnet like a rod, pen or a ring <a data-link-type="biblio" href="#biblio-magitact">[MAGITACT]</a>.
 The user makes coarse gestures in the 3D space around the device using the magnet. Movement of the magnet affects the magnetic field sensed by the compass sensor integrated in the device.
-The temporal pattern of the gesture is then used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
+The temporal pattern of the gesture can be used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
 are some of the use cases.</p>
     <li data-md="">
-     <p>A common use-case for magnetometers is sensor fusion in order to generate an Orientation Sensor which is stationary to the Earth plane, or a compass, which is basically the former with corrections to the declination depending on geolocation position, such that it points to the true north.</p>
+     <p>Indoor navigation. Navigation systems can use magnetometer data on mobile devices <a data-link-type="biblio" href="#biblio-magindoorpos">[MAGINDOORPOS]</a> to detect the magnetic field inside a building. With sufficient local variability, the anomalies can be utilized in self-localization. Use cases for indoor navigation include, for example, proximity advertising, way finding in malls or airports, and geofencing.</p>
     <li data-md="">
-     <p>Indoor navigation system can use magnetometer on mobile phones <a data-link-type="biblio" href="#biblio-magindoorpos">[MAGINDOORPOS]</a>. Use cases for indoor navigation can include, for example, proximity advertising, way finding in malls or airports, and geofencing.</p>
-    <li data-md="">
-     <p>Calculating compass heading as detailed in <a href="#compass">§9 Compass Heading Using Magnetometers</a>.</p>
-    <li data-md="">
-     <p>Head mount tracking in Virtual Reality can use magnetometer data to help in calibration of gyroscope readings and align yaw readings with the magnetic north.</p>
+     <p>Metal detection. Magnetometers can be used by utility applications to detect the presence of metal nearby, e.g. finding inclusions hidden within objects.</p>
    </ul>
-   <div class="note" role="note"> Requirements with respect to data coasrceness and sampling frequency can vary depending on the use case at hand. For example, metal detection or input using magnetic button can likely be implemented with coarser data and using lower sampling frequency compared to gesture recognition, indoor navigation, or VR use cases. In sensor fusion use cases, the sampling frequency that yeilds optimal results is dependent on e.g. sensor fusion algorithm and characteristics of other motion sensors involved. </div>
+   <div class="note" role="note"> Requirements with respect to data coarseness and sampling frequency can vary depending on the use case at hand. For example, metal detection or input using magnetic button can likely be implemented with coarser data and using lower sampling frequency compared to gesture recognition, indoor navigation, or VR and AR use cases. In sensor fusion use cases, the sampling frequency that yeilds optimal results is dependent on e.g. sensor fusion algorithm and characteristics of other motion sensors involved. </div>
    <h2 class="heading settled" data-level="9" id="compass"><span class="secno">9. </span><span class="content">Compass Heading Using Magnetometers</span><a class="self-link" href="#compass"></a></h2>
    <p><em>This section is non-normative</em>.</p>
    <p>Compasses, instruments that align themselves with the magnetic poles of the Earth, have been used in navigation for centuries.
@@ -1893,6 +1889,11 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[motionsensors]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/motion-sensors/#absolute-orientation">absolute orientation sensor</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[permissions]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/permissions/#dom-permissionname-magnetometer">"magnetometer"</a>
@@ -1932,6 +1933,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd>Janne Haverinen, Anssi Kemppainen. <a href="https://doi.org/10.1016%2Fj.robot.2009.07.018">Global indoor self-localization based on the ambient magnetic field</a>. Informational. URL: <a href="https://doi.org/10.1016%2Fj.robot.2009.07.018">https://doi.org/10.1016%2Fj.robot.2009.07.018</a>
    <dt id="biblio-magitact">[MAGITACT]
    <dd>Hamed Ketabdar, Kamer Ali Yüksel, Mehran Roshandel. <a href="http://dl.acm.org/citation.cfm?id=1720048">Magitact</a>. Informational. URL: <a href="http://dl.acm.org/citation.cfm?id=1720048">http://dl.acm.org/citation.cfm?id=1720048</a>
+   <dt id="biblio-motion-sensors">[MOTION-SENSORS]
+   <dd>Kenneth Christiansen; Alexander Shalamov. <a href="https://www.w3.org/TR/motion-sensors/">Motion Sensors Explainer</a>. 30 August 2017. NOTE. URL: <a href="https://www.w3.org/TR/motion-sensors/">https://www.w3.org/TR/motion-sensors/</a>
    <dt id="biblio-vrbutton">[VRBUTTON]
    <dd>Boris Smus. <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=445926">Magnetic input for Google cardboard</a>. Informational. URL: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=445926">https://bugs.chromium.org/p/chromium/issues/detail?id=445926</a>
   </dl>

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
   <link href="https://www.w3.org/TR/magnetometer/" rel="canonical">
-  <meta content="6f89316e1c484a982df43fd2bc2caa38a69d2b28" name="document-revision">
+  <meta content="f487f212b895ae62cd2412cf654910bc941abbe3" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1592,7 +1592,7 @@ validation of the user’s location. For example, if the end user is connected t
 field associated with geo IP information can be compared with magnetometer readings at real
 location, therefore, tell whether user is using VPN or not.</p>
    <p>Uncalibrated magnetometer readings could be affected by magnetized objects nearby, such as jewelry,
-thereby exposing information that might be used for <a data-link-type="dfn" href="https://w3c.github.io/sensors#keystroke-monitoring" id="ref-for-keystroke-monitoring">keystroke monitoring</a>.</p>
+thereby exposing information that might be used for <a data-link-type="dfn" href="https://w3c.github.io/sensors/#keystroke-monitoring" id="ref-for-keystroke-monitoring">keystroke monitoring</a>.</p>
    <p>To mitigate these specific threats, user agents should
 use one or both of the following mitigation strategies:</p>
    <ul>
@@ -1601,20 +1601,20 @@ use one or both of the following mitigation strategies:</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#reduce-accuracy" id="ref-for-reduce-accuracy">reduce accuracy</a> of sensor readings</p>
    </ul>
-   <p>These mitigation strategies complement the <a data-link-type="dfn" href="https://w3c.github.io/sensors#mitigation-strategies" id="ref-for-mitigation-strategies">generic mitigations</a> defined in
+   <p>These mitigation strategies complement the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#mitigation-strategies" id="ref-for-mitigation-strategies">generic mitigations</a> defined in
 the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a>.</p>
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="magnetometer-sensor-type">Magnetometer</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type">sensor type</a> has two associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> subclasses, <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer①">Magnetometer</a></code> and <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer①">UncalibratedMagnetometer</a></code>.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer②">Magnetometer</a></code> and <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer②">UncalibratedMagnetometer</a></code> have an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-permission-names" id="ref-for-sensor-permission-names">sensor permission name</a> which is <a class="idl-code" data-link-type="enum-value" href="https://w3c.github.io/permissions/#dom-permissionname-magnetometer" id="ref-for-dom-permissionname-magnetometer">"magnetometer"</a>.</p>
-   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#magnetometer-sensor-type" id="ref-for-magnetometer-sensor-type">Magnetometer</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">values</a> contain <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑦">magnetic field</a> about the corresponding axes. Values can contain also device’s <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field①">uncalibrated magnetic field</a> and <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion②">hard iron distortion</a> depending on which object was instantiated.</p>
-   <p>For uncalibrated magnetometer, the <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading①">latest reading</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">values</a> contain <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field②">uncalibrated magnetic field</a> around the 3 different axes,
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="magnetometer-sensor-type">Magnetometer</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-type" id="ref-for-sensor-type">sensor type</a> has two associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> subclasses, <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer①">Magnetometer</a></code> and <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer①">UncalibratedMagnetometer</a></code>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer②">Magnetometer</a></code> and <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer②">UncalibratedMagnetometer</a></code> have an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-permission-names" id="ref-for-sensor-permission-names">sensor permission name</a> which is <a class="idl-code" data-link-type="enum-value" href="https://w3c.github.io/permissions/#dom-permissionname-magnetometer" id="ref-for-dom-permissionname-magnetometer">"magnetometer"</a>.</p>
+   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#magnetometer-sensor-type" id="ref-for-magnetometer-sensor-type">Magnetometer</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">values</a> contain <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑦">magnetic field</a> about the corresponding axes. Values can contain also device’s <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field①">uncalibrated magnetic field</a> and <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion②">hard iron distortion</a> depending on which object was instantiated.</p>
+   <p>For uncalibrated magnetometer, the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading①">latest reading</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">values</a> contain <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field②">uncalibrated magnetic field</a> around the 3 different axes,
 and three additional <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry②">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key②">keys</a> are "xBias", "yBias", "zBias" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value②">values</a> contain the <a data-link-type="dfn" href="#hard-iron-distortion" id="ref-for-hard-iron-distortion③">hard iron distortion</a> correction around the 3 different axes.</p>
    <p>The sign of the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑧">magnetic field</a> values must be according to the
-right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> (see figure below).</p>
+right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> (see figure below).</p>
    <p><img alt="Magnetometer coordinate system." onerror="this.src=&apos;images/magnetometer_coordinate_system.png&apos;" src="images/magnetometer_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <h3 class="heading settled" data-level="4.1" id="reference-frame"><span class="secno">4.1. </span><span class="content">Reference Frame</span><a class="self-link" href="#reference-frame"></a></h3>
-   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> represents the reference frame for the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer③">Magnetometer</a></code> and the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer③">UncalibratedMagnetometer</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-readings" id="ref-for-sensor-readings">readings</a>.
-It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
+   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> represents the reference frame for the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer③">Magnetometer</a></code> and the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer③">UncalibratedMagnetometer</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-reading" id="ref-for-sensor-reading">readings</a>.
+It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="magnetometer-interface"><span class="secno">5.1. </span><span class="content">The Magnetometer Interface</span><a class="self-link" href="#magnetometer-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Magnetometer" data-dfn-type="constructor" data-export="" data-lt="Magnetometer(sensorOptions)|Magnetometer()" id="dom-magnetometer-magnetometer"><code>Constructor</code><a class="self-link" href="#dom-magnetometer-magnetometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-magnetometersensoroptions" id="ref-for-dictdef-magnetometersensoroptions">MagnetometerSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Magnetometer/Magnetometer(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-magnetometer-magnetometer-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-magnetometer-magnetometer-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>,
@@ -1632,7 +1632,7 @@ It can be either the <a data-link-type="dfn" href="https://w3c.github.io/acceler
 };
 </pre>
    <p>To construct a <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer④">Magnetometer</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-a-magnetometer-object" id="ref-for-construct-a-magnetometer-object">construct a magnetometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑤">Magnetometer</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑥">Magnetometer</a></code> are "frequency" and "referenceFrame".</p>
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑥">Magnetometer</a></code> are "frequency" and "referenceFrame".</p>
    <h4 class="heading settled" data-level="5.1.1" id="magnetometer-x"><span class="secno">5.1.1. </span><span class="content">Magnetometer.x</span><a class="self-link" href="#magnetometer-x"></a></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer⑦">Magnetometer</a></code> interface represents the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field⑨">magnetic field</a> around X-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <code>this</code> and "x" as arguments.</p>
@@ -1655,7 +1655,7 @@ In other words, this attribute returns the result of invoking <a data-link-type=
 };
 </pre>
    <p>To construct an <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer④">UncalibratedMagnetometer</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-a-magnetometer-object" id="ref-for-construct-a-magnetometer-object①">construct a magnetometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑤">UncalibratedMagnetometer</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options①">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑥">UncalibratedMagnetometer</a></code> are "frequency" and "referenceFrame".</p>
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options①">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑥">UncalibratedMagnetometer</a></code> are "frequency" and "referenceFrame".</p>
    <h4 class="heading settled" data-level="5.2.1" id="uncalibrated-magnetometer-x"><span class="secno">5.2.1. </span><span class="content">UncalibratedMagnetometer.x</span><a class="self-link" href="#uncalibrated-magnetometer-x"></a></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-uncalibratedmagnetometer-x" id="ref-for-dom-uncalibratedmagnetometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uncalibratedmagnetometer" id="ref-for-uncalibratedmagnetometer⑦">UncalibratedMagnetometer</a></code> interface represents the <a data-link-type="dfn" href="#uncalibrated-magnetic-field" id="ref-for-uncalibrated-magnetic-field③">uncalibrated magnetic field</a> around X-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <code>this</code> and "x" as arguments.</p>
@@ -1690,7 +1690,7 @@ In other words, this attribute returns the result of invoking <a data-link-type=
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer①②">Magnetometer</a></code>.</p>
+      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with <code class="idl"><a data-link-type="idl" href="#magnetometer" id="ref-for-magnetometer①②">Magnetometer</a></code>.</p>
      <li data-md="">
       <p>If <var>allowed</var> is false, then:</p>
       <ol>
@@ -1700,15 +1700,15 @@ In other words, this attribute returns the result of invoking <a data-link-type=
      <li data-md="">
       <p>Let <var>magnetometer</var> be a new instance of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface②">interface</a> identified by <var>magnetometer_interface</var>.</p>
      <li data-md="">
-      <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>magnetometer</var> and <var>options</var>.</p>
+      <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors/#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>magnetometer</var> and <var>options</var>.</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-magnetometersensoroptions-referenceframe" id="ref-for-dom-magnetometersensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
       <ol>
        <li data-md="">
-        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> for <var>magnetometer</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> for <var>magnetometer</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>magnetometer</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a>.</p>
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>magnetometer</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a>.</p>
      <li data-md="">
       <p>Return <var>magnetometer</var>.</p>
     </ol>
@@ -1722,8 +1722,9 @@ also affects the accuracy of the reading.
 Presence of electronic items, laptops, batteries, etc also contribute to the soft iron interference.
 Flight Mode option in mobile phones might help in decreasing the electro magnetic interference.</p>
    <p>In addition to the above spatial variations of the <a data-link-type="dfn" href="#magnetic-field" id="ref-for-magnetic-field①②">magnetic field</a>, time based variations,
-like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the earth.</p>
+like solar winds or magnetic storms, also distort the magnetosphere or external magnetic field of the Earth.</p>
    <h2 class="heading settled" data-level="8" id="usecases-and-requirements"><span class="secno">8. </span><span class="content">Use Cases and Requirements</span><a class="self-link" href="#usecases-and-requirements"></a></h2>
+   <p><em>This section is non-normative</em>.</p>
    <p>Magnetometers can be used for a variety of use-cases, such as:</p>
    <ul>
     <li data-md="">
@@ -1736,26 +1737,26 @@ The user makes coarse gestures in the 3D space around the device using the magne
 The temporal pattern of the gesture is then used as a basis for sending different interaction commands to the mobile device. Zooming, turning pages, accepting/rejecting calls, clicking items
 are some of the use cases.</p>
     <li data-md="">
-     <p>In cases, where it is not possible to use orientation sensor, user may need to fuse magnetometer data with with other low-level sensor data, to calculate orientation.</p>
+     <p>A common use-case for magnetometers is sensor fusion in order to generate an Orientation Sensor which is stationary to the Earth plane, or a compass, which is basically the former with corrections to the declination depending on geolocation position, such that it points to the true north.</p>
     <li data-md="">
-     <p>Indoor navigation system may use magnetometer on mobile phones <a data-link-type="biblio" href="#biblio-magindoorpos">[MAGINDOORPOS]</a>. Specific use cases for indoor navigation may include proximity advertising, way finding in malls or airports, geofencing, etc.</p>
+     <p>Indoor navigation system can use magnetometer on mobile phones <a data-link-type="biblio" href="#biblio-magindoorpos">[MAGINDOORPOS]</a>. Use cases for indoor navigation can include, for example, proximity advertising, way finding in malls or airports, and geofencing.</p>
     <li data-md="">
-     <p>Calculating compass heading, more on that in <a href="#compass">§9 Compass Heading Using Magnetometers</a>.</p>
+     <p>Calculating compass heading as detailed in <a href="#compass">§9 Compass Heading Using Magnetometers</a>.</p>
+    <li data-md="">
+     <p>Head mount tracking in Virtual Reality can use magnetometer data to help in calibration of gyroscope readings and align yaw readings with the magnetic north.</p>
    </ul>
-   <p>Metal detection and input using magnetic button may require only coarse data and low sampling rates suffice.
-Gesture recognition or indoor navigation are more real time use cases where there might be a need for more accurate sensor readings and higher sampling rates.
-Head mount tracking in Virtual Reality may require sensor fusion from accelerometer, gyroscope and magnetometer. Magnetometer data may be used to help in calibration of gyroscope readings
-and align yaw readings with the magnetic north. The required sampling rate might depend on the sensor fusion algorithm and characteristics of other motion sensors involved.</p>
+   <div class="note" role="note"> Requirements with respect to data coasrceness and sampling frequency can vary depending on the use case at hand. For example, metal detection or input using magnetic button can likely be implemented with coarser data and using lower sampling frequency compared to gesture recognition, indoor navigation, or VR use cases. In sensor fusion use cases, the sampling frequency that yeilds optimal results is dependent on e.g. sensor fusion algorithm and characteristics of other motion sensors involved. </div>
    <h2 class="heading settled" data-level="9" id="compass"><span class="secno">9. </span><span class="content">Compass Heading Using Magnetometers</span><a class="self-link" href="#compass"></a></h2>
+   <p><em>This section is non-normative</em>.</p>
    <p>Compasses, instruments that align themselves with the magnetic poles of the Earth, have been used in navigation for centuries.
-The earth’s rotational axis defines the geographic north and south poles that we use for
+The Earth’s rotational axis defines the geographic north and south poles that we use for
 map references. It turns out that there is a discrepancy of around 11.5 degrees (around 1000 miles) between the geographic poles and the
 magnetic poles. <a data-link-type="dfn" href="#declination-angle" id="ref-for-declination-angle">Declination angle</a> is applied to the magnetic direction to correct for this situation.</p>
-   <p>If the device is always level to the earth’s surface, compass heading <a data-link-type="biblio" href="#biblio-compassheading">[COMPASSHEADING]</a> can be determined by using just the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x①">x</a></code> and <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-y" id="ref-for-dom-magnetometer-y①">y</a></code> component of the earth’s magnetic field, that
-is, the directions planar with the earth’s surface.
+   <p>If the device is always level to the Earth’s surface, compass heading can be determined by using just the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-x" id="ref-for-dom-magnetometer-x①">x</a></code> and <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-magnetometer-y" id="ref-for-dom-magnetometer-y①">y</a></code> component of the Earth’s magnetic field, that
+is, the directions planar with the Earth’s surface.
 To determine geographic north (or true north) heading, add the appropriate <a data-link-type="dfn" href="#declination-angle" id="ref-for-declination-angle①">declination angle</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="magnetic-declination">Magnetic declination</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="declination-angle">declination angle</dfn> is the angle on the horizontal plane between magnetic north and the true north and depends on the position on the Earth’s surface, and changes over time.
-By convention, declination is positive when magnetic north is east of true north, and negative when it is to the west. You can get real time value for <a data-link-type="dfn" href="#magnetic-declination" id="ref-for-magnetic-declination">magnetic declination</a> e.g. using the <a href="http://www.ngdc.noaa.gov/geomag-web/calculators/declinationHelp">Magnetic declination calculator</a> provided by the National Oceanic and Atmospheric Administration (NOAA).</p>
+By convention, declination is positive when magnetic north is east of true north, and negative when it is to the west. You can get real time value for <a data-link-type="dfn" href="#magnetic-declination" id="ref-for-magnetic-declination">magnetic declination</a> e.g. using the <a href="https://www.ngdc.noaa.gov/geomag-web/calculators/declinationHelp">Magnetic declination calculator</a> provided by the National Oceanic and Atmospheric Administration (NOAA).</p>
    <p>The magnetic north is calculated as follows:</p>
    <div class="example" id="example-7be8f1e8">
     <a class="self-link" href="#example-7be8f1e8"></a> 
@@ -1765,7 +1766,7 @@ sensor<span class="p">.</span>start<span class="p">();</span>
 console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Heading in degrees: '</span> <span class="o">+</span> heading<span class="p">);</span>
 </pre>
    </div>
-   <p>The geographic north at a given latitude and longitude is calculated as follows:</p>
+   <p>The geographic north at a given latitude and longitude can be calculated as follows:</p>
    <div class="example" id="example-9cb49786">
     <a class="self-link" href="#example-9cb49786"></a> 
 <pre class="highlight"><span class="c1">// Get the latitude and longitude, omitted for brevity here.</span>
@@ -1862,27 +1863,27 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[accelerometer]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/accelerometer#device-coordinate-system">device coordinate system</a>
-     <li><a href="https://w3c.github.io/accelerometer#screen-coordinate-system">screen coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer/#device-coordinate-system">device coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">screen coordinate system</a>
     </ul>
    <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
+     <li><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
-     <li><a href="https://w3c.github.io/sensors#initialize-a-sensor-object">initialize a sensor object</a>
-     <li><a href="https://w3c.github.io/sensors#keystroke-monitoring">keystroke monitoring</a>
-     <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">initialize a sensor object</a>
+     <li><a href="https://w3c.github.io/sensors/#keystroke-monitoring">keystroke monitoring</a>
+     <li><a href="https://w3c.github.io/sensors/#latest-reading">latest reading</a>
      <li><a href="https://w3c.github.io/sensors/#limit-max-frequency">limit maximum sampling frequency</a>
-     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
-     <li><a href="https://w3c.github.io/sensors#mitigation-strategies">mitigation strategies</a>
+     <li><a href="https://w3c.github.io/sensors/#local-coordinate-system">local coordinate system</a>
+     <li><a href="https://w3c.github.io/sensors/#mitigation-strategies">mitigation strategies</a>
      <li><a href="https://w3c.github.io/sensors/#reduce-accuracy">reduce accuracy</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-permission-names">sensor permission name</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-readings">sensor readings</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
-     <li><a href="https://w3c.github.io/sensors#supported-sensor-options">supported sensor options</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-permission-names">sensor permission name</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-reading">sensor readings</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-type">sensor type</a>
+     <li><a href="https://w3c.github.io/sensors/#supported-sensor-options">supported sensor options</a>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
@@ -1927,10 +1928,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-compassheading">[COMPASSHEADING]
-   <dd><a href="http://www51.honeywell.com/aero/common/documents/myaerospacecatalog-documents/Defense_Brochures-documents/Magnetic__Literature_Application_notes-documents/AN203_Compass_Heading_Using_Magnetometers.pdf">Compass Heading using Magnetometer</a>. Informational. URL: <a href="http://www51.honeywell.com/aero/common/documents/myaerospacecatalog-documents/Defense_Brochures-documents/Magnetic__Literature_Application_notes-documents/AN203_Compass_Heading_Using_Magnetometers.pdf">http://www51.honeywell.com/aero/common/documents/myaerospacecatalog-documents/Defense_Brochures-documents/Magnetic__Literature_Application_notes-documents/AN203_Compass_Heading_Using_Magnetometers.pdf</a>
    <dt id="biblio-magindoorpos">[MAGINDOORPOS]
-   <dd>IndoorAtlas. <a href="http://www.indooratlas.com/wp-content/uploads/2016/03/magnetic_positioning_opus_jun2014.pdf">Indoor positioning using magnetometer</a>. Informational. URL: <a href="http://www.indooratlas.com/wp-content/uploads/2016/03/magnetic_positioning_opus_jun2014.pdf">http://www.indooratlas.com/wp-content/uploads/2016/03/magnetic_positioning_opus_jun2014.pdf</a>
+   <dd>Janne Haverinen, Anssi Kemppainen. <a href="https://doi.org/10.1016%2Fj.robot.2009.07.018">Global indoor self-localization based on the ambient magnetic field</a>. Informational. URL: <a href="https://doi.org/10.1016%2Fj.robot.2009.07.018">https://doi.org/10.1016%2Fj.robot.2009.07.018</a>
    <dt id="biblio-magitact">[MAGITACT]
    <dd>Hamed Ketabdar, Kamer Ali Yüksel, Mehran Roshandel. <a href="http://dl.acm.org/citation.cfm?id=1720048">Magitact</a>. Informational. URL: <a href="http://dl.acm.org/citation.cfm?id=1720048">http://dl.acm.org/citation.cfm?id=1720048</a>
    <dt id="biblio-vrbutton">[VRBUTTON]


### PR DESCRIPTION
- Editorial Use Cases and Requirements update, remove RFC 2119 terms, s/earth/Earth/g
- Avoid redundant redirects:
  https://w3c.github.io/sensors -> https://w3c.github.io/sensors/
  https://w3c.github.io/accelerometer -> https://w3c.github.io/accelerometer/
- Fix Broken fragments:
  https://w3c.github.io/sensors#sensor-readings
- Reduce informative references to scientific papers
- Explicitly note "This section is non-normative" in:
  Use Cases and Requirements
  Compass Heading Using Magnetometers


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/pull/47.html" title="Last updated on Mar 15, 2018, 9:00 AM GMT (a0fef19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/47/c3dab40...a0fef19.html" title="Last updated on Mar 15, 2018, 9:00 AM GMT (a0fef19)">Diff</a>