### PR TITLE
Make default allowlist normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -190,6 +190,8 @@ The <dfn id="magnetometer-sensor-type">Magnetometer</dfn> <a>sensor type</a> has
 
 The {{Magnetometer}} and {{UncalibratedMagnetometer}} have an associated [=sensor permission name=] which is <a for="PermissionName" enum-value>"magnetometer"</a>.
 
+The <a>Magnetometer</a> is a [=policy-controlled feature=] identified by the string "magnetometer". Its [=default allowlist=] is `'self'`.
+
 The [=latest reading=] for a {{Sensor}} of <a>Magnetometer</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>magnetic field</a>
 about the corresponding axes. Values can contain also device's [=uncalibrated magnetic field=] and [=hard iron distortion=]


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/pull/57.html" title="Last updated on Sep 1, 2021, 3:18 PM UTC (b80a8c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/57/3e14ed5...b80a8c9.html" title="Last updated on Sep 1, 2021, 3:18 PM UTC (b80a8c9)">Diff</a>