### PR TITLE
Update stability status in SOTD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,6 @@ Markup Shorthands: markdown on
 Inline Github Issues: true
 !Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/main/magnetometer">web-platform-tests on GitHub</a>
 Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
-Include MDN Panels: if possible
 Status Text:
   This specification is looking for developer feedback and high value use cases. Please provide your feedback via <a href="https://github.com/w3c/magnetometer/issues/59">GitHub</a>.
 

--- a/index.bs
+++ b/index.bs
@@ -20,7 +20,10 @@ Inline Github Issues: true
 !Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/main/magnetometer">web-platform-tests on GitHub</a>
 Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
 Include MDN Panels: if possible
-Status Text: This specification is looking for developer feedback and high value use cases. Please provide your feedback via <a href="https://github.com/w3c/magnetometer/issues/59">GitHub</a>.
+Status Text:
+  This specification is looking for developer feedback and high value use cases. Please provide your feedback via <a href="https://github.com/w3c/magnetometer/issues/59">GitHub</a>.
+
+  This document is maintained and updated at any time. Some parts of this document are work in progress.
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR


### PR DESCRIPTION
Required to pass specberus sotd.draft-stability test and to unblock TR publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/pull/62.html" title="Last updated on Dec 3, 2021, 11:34 AM UTC (cd8b5ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/62/dc7e187...cd8b5ed.html" title="Last updated on Dec 3, 2021, 11:34 AM UTC (cd8b5ed)">Diff</a>