### PR TITLE
editorial: Remove "sensor reading" custom anchor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -36,7 +36,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: sensor type
     text: mitigation strategies; url: mitigation-strategies
     text: local coordinate system
-    text: sensor readings; url: sensor-reading
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
     text: keystroke monitoring; url: keystroke-monitoring
     text: sensor permission name; url: sensor-permission-names


### PR DESCRIPTION
w3c/sensors#456 started exporting the definition, so there is no need to
have a custom anchor anymore.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/magnetometer/pull/64.html" title="Last updated on Jan 30, 2023, 10:30 AM UTC (563133b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/64/cf7e471...rakuco:563133b.html" title="Last updated on Jan 30, 2023, 10:30 AM UTC (563133b)">Diff</a>