### PR TITLE
Define a separate "Uncalibrated Magnetometer" sensor type, tighten definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -185,30 +185,45 @@ use one or both of the following mitigation strategies:
 These mitigation strategies complement the [=mitigation strategies|generic mitigations=] defined in
 the Generic Sensor API [[!GENERIC-SENSOR]].
 
+Permissions Policy integration {#permissions-policy-integration}
+==============================
+
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn data-lt="magnetometer-feature" export>magnetometer</dfn></code>". Its [=default allowlist=] is "`self`".
+
 Model {#model}
 =====
 
-The <dfn id="magnetometer-sensor-type">Magnetometer</dfn> <a>sensor type</a> has two associated {{Sensor}} subclasses, {{Magnetometer}} and {{UncalibratedMagnetometer}}.
+The <dfn id="magnetometer-sensor-type">Magnetometer</dfn> <a>sensor type</a> has the following associated data:
 
-The <a>Magnetometer</a> is a [=powerful feature=] that is identified by the
-[=powerful feature/name=] "magnetometer", which is also its associated
-[=sensor permission name=]. Its [=powerful feature/permission revocation algorithm=] is the
-result of calling the [=generic sensor permission revocation algorithm=] with
-"magnetometer".
+ : [=Extension sensor interface=]
+ :: {{Magnetometer}}
+ : [=Sensor permission names=]
+ :: "`magnetometer`"
+ : [=Sensor feature names=]
+ :: "[=magnetometer-feature|magnetometer=]"
+ : [=powerful feature/Permission revocation algorithm=]
+ :: Invoke the [=generic sensor permission revocation algorithm=] with "`magnetometer`".
 
-The <a>Magnetometer</a> is a [=policy-controlled feature=] identified by the string "magnetometer". Its [=default allowlist=] is `'self'`.
+The [=latest reading=] for a {{Sensor}} whose [=sensor type=] is [=Magnetometer=] must include:
+ - Three [=map/entries=] whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>magnetic field</a> about the corresponding axes.
 
-The [=latest reading=] for a {{Sensor}} of <a>Magnetometer</a> <a>sensor type</a> includes three [=map/entries=]
-whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>magnetic field</a>
-about the corresponding axes. Values can contain also device's [=uncalibrated magnetic field=] and [=hard iron distortion=]
-depending on which object was instantiated.
+The <dfn id="uncalibrated-magnetometer-sensor-type">Uncalibrated Magnetometer</dfn> <a>sensor type</a> has the following associated data:
 
-For uncalibrated magnetometer, the [=latest reading=] includes three [=map/entries=] whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>uncalibrated magnetic field</a> around the 3 different axes,
-and three additional [=map/entries=] whose [=map/keys=] are "xBias", "yBias", "zBias" and whose [=map/values=] contain the <a>hard iron distortion</a> correction around the 3 different axes.
+ : [=Extension sensor interface=]
+ :: {{UncalibratedMagnetometer}}
+ : [=Sensor permission names=]
+ :: "`magnetometer`"
+ : [=Sensor feature names=]
+ :: "[=magnetometer-feature|magnetometer=]"
+ : [=powerful feature/Permission revocation algorithm=]
+ :: Invoke the [=generic sensor permission revocation algorithm=] with "`magnetometer`".
+
+The [=latest reading=] for a {{Sensor}} whose [=sensor type=] is [=Uncalibrated Magnetometer=] must include:
+ - Three [=map/entries=] whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>uncalibrated magnetic field</a> around the 3 different axes.
+ - Three additional [=map/entries=] whose [=map/keys=] are "xBias", "yBias", "zBias" and whose [=map/values=] contain the <a>hard iron distortion</a> correction around the 3 different axes.
 
 The sign of the <a>magnetic field</a> values must be according to the
 right-hand convention in a [=local coordinate system=] (see figure below).
-
 
 <img src="images/magnetometer_coordinate_system.svg" onerror="if (/\.svg$/.test(this.src)) this.src='images/magnetometer_coordinate_system.png'" style="display: block;margin: auto;" alt="Magnetometer coordinate system.">
 


### PR DESCRIPTION
Fixing #65 requires having a sensor type for each entry that will be added to the per-type virtual sensor metadata map, so add a definition for Uncalibrated Magnetometer, which was piggybacking on the one for Magnetometer so far.

While here, do some housekeeping:
* Move the permissions-policy text to a separate section for clarity.
* Stop saying "Magnetometer a policy-controlled feature" because it does not make much sense. The most common way to list features is by saying something like "this spec defines a feature identifed by the string 'foo'". In our case, that string is "magnetometer".
* Define and export the feature identifier above, as it is used in e.g. the Orientation Sensor specification.
* Explicitly list all data associated with the spec's two sensor types using a definition list instead of a very long paragraph.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/magnetometer/pull/66.html" title="Last updated on Oct 24, 2023, 1:17 PM UTC (96f7b56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/66/cf05a1b...rakuco:96f7b56.html" title="Last updated on Oct 24, 2023, 1:17 PM UTC (96f7b56)">Diff</a>