### PR TITLE
Define and export "magnetometer" permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -198,11 +198,11 @@ The <dfn id="magnetometer-sensor-type">Magnetometer</dfn> <a>sensor type</a> has
  : [=Extension sensor interface=]
  :: {{Magnetometer}}
  : [=Sensor permission names=]
- :: "`magnetometer`"
+ :: "<code><dfn permission export>magnetometer</dfn></code>"
  : [=Sensor feature names=]
  :: "[=magnetometer-feature|magnetometer=]"
  : [=powerful feature/Permission revocation algorithm=]
- :: Invoke the [=generic sensor permission revocation algorithm=] with "`magnetometer`".
+ :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>magnetometer</a></code>".
 
 The [=latest reading=] for a {{Sensor}} whose [=sensor type=] is [=Magnetometer=] must include:
  - Three [=map/entries=] whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>magnetic field</a> about the corresponding axes.


### PR DESCRIPTION
This is similar to w3c/accelerometer#67: with this we can eventually link to the permission name from https://w3c.github.io/permissions-registry/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/magnetometer/pull/67.html" title="Last updated on Oct 24, 2023, 2:28 PM UTC (746e6c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/67/7e72aff...rakuco:746e6c9.html" title="Last updated on Oct 24, 2023, 2:28 PM UTC (746e6c9)">Diff</a>