### PR TITLE
Rewrite Automation section after w3c/sensors#470

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -40,9 +40,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: keystroke monitoring; url: keystroke-monitoring
     text: sensor permission name; url: sensor-permission-names
     text: supported sensor options
-    text: automation
-    text: mock sensor type
-    text: mock sensor reading values
 urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
   type: dfn
     text: device coordinate system
@@ -381,38 +378,45 @@ Abstract Operations {#abstract-opertaions}
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the [=magnetic field=] in the X, Y and Z axis
-for the purposes of testing a user agent's implementation of {{Magnetometer}} and {{UncalibratedMagnetometer}} APIs.
 
-<h3 id="mock-magnetometer-type">Mock Sensor Type</h3>
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Magnetometer=]-specific virtual sensor metadata.
 
-The {{Magnetometer}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"magnetometer"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+Magnetometer automation {#magnetometer-automation}
+-----------------------
 
-<pre class="idl">
-  dictionary MagnetometerReadingValues {
-    required double? x;
-    required double? y;
-    required double? z;
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`magnetometer`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Magnetometer=] and [=reading parsing algorithm=] is [=parse XYZ reading=].
 
-The {{UncalibratedMagnetometer}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"uncalibrated-magnetometer"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+Uncalibrated Magnetometer automation {#uncalibrated-magnetometer-automation}
+------------------------------------
 
-<pre class="idl">
-  dictionary UncalibratedMagnetometerReadingValues {
-    required double? x;
-    required double? y;
-    required double? z;
-    required double? xBias;
-    required double? yBias;
-    required double? zBias;
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`uncalibrated-magnetometer`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [UncalibratedMagnetometer](#uncalibrated-magnetometer-interface) and [=reading parsing algorithm=] is [=uncalibrated magnetometer reading parsing algorithm=].
+
+<h4 dfn>Uncalibrated Magnetometer reading parsing algorithm</h4>
+<div algorithm="uncalibrated magnetometer reading parsing algorithm">
+    : input
+    :: |parameters|, a JSON {{Object}}
+    : output
+    :: A [=sensor reading=] or **undefined**
+
+    1.  Let |reading| be a new [=sensor reading=].
+    1.  Let |value| be a new [=sensor reading=].
+    1.  Let |reading| be the result of [=parse XYZ reading=] with |parameters|.
+    1.  If |reading| is "undefined".
+        1.  Return "undefined".
+    1. Let |key| be the [=/list=] « "`xBias`", "`yBias`", "`zBias`" ».
+    1.  [=map/For each=] |key| → let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
+        1.  If |value| is "undefined".
+            1.  Return "undefined".
+        1.  [=map/Set=] |reading|[|key|] to |value|.
+    1.  Return |reading|.
 
 Limitations of Magnetometer Sensors {#limitations-magnetometer}
 ==============

--- a/index.bs
+++ b/index.bs
@@ -400,7 +400,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 : [=map/key=]
 :: "`uncalibrated-magnetometer`"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [UncalibratedMagnetometer](#uncalibrated-magnetometer-interface) and [=reading parsing algorithm=] is [=uncalibrated magnetometer reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Uncalibrated Magnetometer=] and [=reading parsing algorithm=] is the [=uncalibrated magnetometer reading parsing algorithm=].
 
 <h4 dfn>Uncalibrated Magnetometer reading parsing algorithm</h4>
 <div algorithm="uncalibrated magnetometer reading parsing algorithm">
@@ -409,17 +409,17 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
     : output
     :: A [=sensor reading=] or **undefined**
 
-    1.  Let |reading| be a new [=sensor reading=].
-    1.  Let |value| be a new [=sensor reading=].
     1.  Let |reading| be the result of [=parse XYZ reading=] with |parameters|.
-    1.  If |reading| is "undefined".
-        1.  Return "undefined".
-    1. Let |key| be the [=/list=] « "`xBias`", "`yBias`", "`zBias`" ».
-    1.  [=map/For each=] |key| → let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
-        1.  If |value| is "undefined".
-            1.  Return "undefined".
-        1.  [=map/Set=] |reading|[|key|] to |value|.
+    1.  If |reading| is **undefined**.
+        1.  Return **undefined**.
+    1.  Let |keys| be the [=/list=] « "`xBias`", "`yBias`", "`zBias`" ».
+    1.  [=list/For each=] |key| of |keys|
+        1.  Let |value| be the result of invoking [=parse single-value number reading=] with |parameters| and |key|.
+            1.  If |value| is **undefined**.
+                1.  Return **undefined**.
+        1.  [=map/Set=] |reading|[|key|] to |value|[|key|].
     1.  Return |reading|.
+</div>
 
 Limitations of Magnetometer Sensors {#limitations-magnetometer}
 ==============


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Magnetometer Sensor spec to the changes:

- Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
- Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "magnetometer" or "uncalibrated-magnetometer" entry in MockSensorType and an appropriate virtual sensor metadata entry. 

This is enough to integrate properly with the Generic Sensor spec and allow Magnetometer and Uncalibrated Magnetometer virtual sensors to be created and used.

Fixes #65.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JuhaVainio/magnetometer/pull/69.html" title="Last updated on Oct 26, 2023, 7:54 AM UTC (feb72a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/69/2b1256c...JuhaVainio:feb72a1.html" title="Last updated on Oct 26, 2023, 7:54 AM UTC (feb72a1)">Diff</a>