### PR TITLE
Update permission name and feature name references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -47,10 +47,6 @@ urlPrefix: https://w3c.github.io/motion-sensors/; spec: MOTIONSENSORS
   type: dfn
     text: Absolute Orientation Sensor; url: absolute-orientation
 </pre>
-<pre class=link-defaults>
-spec:orientation-event; type:dfn; text:magnetometer-feature
-spec:orientation-event; type:permission; text:magnetometer
-</pre>
 <pre class=biblio>
 {
    "MAGITACT": {
@@ -183,7 +179,7 @@ the Generic Sensor API [[!GENERIC-SENSOR]].
 Permissions Policy integration {#permissions-policy-integration}
 ==============================
 
-This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a data-lt="magnetometer-feature">magnetometer</a></code>" defined in [[DEVICE-ORIENTATION]].
+This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a permission>magnetometer</a></code>" defined in [[DEVICE-ORIENTATION]].
 
 Model {#model}
 =====
@@ -193,9 +189,9 @@ The <dfn id="magnetometer-sensor-type">Magnetometer</dfn> <a>sensor type</a> has
  : [=Extension sensor interface=]
  :: {{Magnetometer}}
  : [=Sensor permission names=]
- :: "<code><a permission>magnetometer</a></code>" (defined in [[DEVICE-ORIENTATION]])
+ :: "<code><a permission>magnetometer</a></code>"
  : [=Sensor feature names=]
- :: "[=magnetometer-feature|magnetometer=]" (defined in [[DEVICE-ORIENTATION]])
+ :: <a permission>"magnetometer"</a>
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>magnetometer</a></code>".
  : [=Virtual sensor type=]
@@ -209,9 +205,9 @@ The <dfn id="uncalibrated-magnetometer-sensor-type">Uncalibrated Magnetometer</d
  : [=Extension sensor interface=]
  :: {{UncalibratedMagnetometer}}
  : [=Sensor permission names=]
- :: "<code><a permission>magnetometer</a></code>" (defined in [[DEVICE-ORIENTATION]])
+ :: "<code><a permission>magnetometer</a></code>"
  : [=Sensor feature names=]
- :: "[=magnetometer-feature|magnetometer=]" (defined in [[DEVICE-ORIENTATION]])
+ :: <a permission>"magnetometer"</a>
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>magnetometer</a></code>".
  : [=Virtual sensor type=]


### PR DESCRIPTION
The permission names are shared across Permissions and Permissions Policy specs: https://www.w3.org/TR/permissions/#relationship-to-permissions-policy

Similar to https://github.com/w3c/accelerometer/pull/80


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/pull/75.html" title="Last updated on Oct 8, 2024, 10:59 AM UTC (d9a5ac6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/75/94a1116...d9a5ac6.html" title="Last updated on Oct 8, 2024, 10:59 AM UTC (d9a5ac6)">Diff</a>