### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,13 @@ Markup Shorthands: markdown on
 Inline Github Issues: true
 !Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/main/magnetometer">web-platform-tests on GitHub</a>
 Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
-Status Text:
+Status Text: <div class="advisement">
+  This API is not enabled by default in any browser engine.
+  In Blink, it requires enabling a feature flag and is not available in stable releases.
+  Implementer standards positions:
+  <a href="https://github.com/WebKit/standards-positions/issues/347">WebKit</a>,
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  </div>
   This specification is looking for developer feedback and high value use cases. Please provide your feedback via <a href="https://github.com/w3c/magnetometer/issues/59">GitHub</a>.
 
   This document is maintained and updated at any time. Some parts of this document are work in progress.


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/magnetometer/pull/77.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (2b02857)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/77/32fd8cb...marcoscaceres:2b02857.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (2b02857)">Diff</a>