### PR TITLE
Add implementation status note to SotD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -20,6 +20,8 @@ Inline Github Issues: true
 !Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/main/magnetometer">web-platform-tests on GitHub</a>
 Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
 Status Text:
+  <p class="advisement">Multiple browser engines have expressed concerns about this specification. It is not available by default in any browser engine. It is not expected to advance to W3C Recommendation in its current form.</p>
+
   This specification is looking for developer feedback and high value use cases. Please provide your feedback via <a href="https://github.com/w3c/magnetometer/issues/59">GitHub</a>.
 
   This document is maintained and updated at any time. Some parts of this document are work in progress.


### PR DESCRIPTION
Addresses the TAG's 'at a glance' concern in design-reviews#1187.

The paragraph uses `<p class="advisement">` so it renders as a highlighted box, making the implementation-status signal visible at a glance rather than blending into the SotD boilerplate.

Reviewed in fork by @marcoscaceres and @jyasskin: https://github.com/christianliebel/magnetometer/pull/1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/magnetometer/pull/78.html" title="Last updated on May 14, 2026, 11:48 AM UTC (2815d05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/magnetometer/78/32fd8cb...christianliebel:2815d05.html" title="Last updated on May 14, 2026, 11:48 AM UTC (2815d05)">Diff</a>